### PR TITLE
Move Strapi APP_KEYS to secrets

### DIFF
--- a/strapi/kubernetes/base/deployment.yml
+++ b/strapi/kubernetes/base/deployment.yml
@@ -31,6 +31,8 @@ spec:
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-config-strapi-secret
             - secretRef:
+                name: ${BUILD_REPOSITORY_NAME}-app-keys-secret
+            - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-meilisearch-secret
             - secretRef:
                 name: minio-secret-standalone

--- a/strapi/kubernetes/base/secrets/app-keys.secret.dev.yml
+++ b/strapi/kubernetes/base/secrets/app-keys.secret.dev.yml
@@ -1,0 +1,20 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  creationTimestamp: null
+  name: city-library-strapi-app-keys-secret
+  namespace: standalone
+spec:
+  encryptedData:
+    APP_KEYS: AgBrHoiVXmrY9e7Cc3NvimuAjGefNtkLMD/I4g3w8ZZhNojyR4H/NzQPm0Nne7wR4l4WzV794N2p23cTPhOimLJQ/zoSMsqdur9Hbd9od/rhdq0/UoNREPUlS3Jt3DN4d0fXmfHVKdhvZ9lW1kAKku1MM8gDif7VnwIz74ahMOTKu5wKv5UZGA8N58Gh6uhMjiUgFg4YFR/K1u4UONXG9mrnjGzHJfcabdfasYpT5D7tofRwsaARfMYBqr4evheS0iEIRM7P+a7Mgl7rSIYLAFlYv3StbgnI3CgX3MKDx+c3F8rhb8bDG6YEN4QhYfaEs2vR677xGgRsu6vWbd5jHw9apjerCi/yQHQcZRarIX8KPSTaFhQMqJRevUjI5pxKaoBS7GGv4qe8Q6tSSJPceHjP+3gYaAWap8vPnxp8oLLwpERLmXdiB++EmTWgX2kH/SzmwIPm59RXTOlrzB2IGwvDf0KypHA9/b3aUhG83DZqSwCglYyIcOh21zNJyOhWX5krjcwgkacuwE+g8cKl4ZcoHPVp/Vad1A/waeJgqY7APTrGr50/bCTFDP7ncAJHzMAxHK/Y6TCyjTUVhMiijfwTBZBNpMUsToj47FLLsp67Sw3M2j/LSS2uqkXiVNX8cCETIgflYCChKexHmD+ge0zaFLCqhaDqLMFAMvCmMIxDUzT8B6enRbLFq84CMnn3HQzLTTkl/aJm028C+8b8C7YB3Mo/pvgf0fPR2DjdWWm0kXVW7H7qeWFU/nTOOsh3RQ6cNhE7VEeC2EYnSp5OBxFgSyXEN9T4e1Eb/mH++sCL6GQBaeeghUzv9cnch4yBkfhZzjOQt43a5YbyumBi2EwdyZcxbQQ6f1Fc3+9jWeKekHswa1QLTKjuI4lud7WbaQB7TYHs4rk5PFeHOgWHBfZyTOPkN9Im43EWhCpjxEEpO4+g3hLR8GbLtHdz6GpJPAw2SMprSHnTzjXWIvoMz6I9Fe8/HL0Ln6XAklpj585QWuVCb+Ymm2mTZRNoDy3NWuSuoz5X
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      creationTimestamp: null
+      name: city-library-strapi-app-keys-secret
+      namespace: standalone
+

--- a/strapi/kubernetes/base/secrets/app-keys.secret.prod.yml
+++ b/strapi/kubernetes/base/secrets/app-keys.secret.prod.yml
@@ -1,0 +1,20 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  creationTimestamp: null
+  name: city-library-strapi-app-keys-secret
+  namespace: standalone
+spec:
+  encryptedData:
+    APP_KEYS: AgBfv6dY4y/7xcty9bTqpBZAkX+DX/dLWgjmi4srf2VJwl16q2C5p9sazDvEJ8UAt4hXC55QTNts+VhumIqlj1jfO2iz03W4KAONlpPHZZySZBOmNF4Djh0QIw2sfhrbWk5FL7zBb04Lw95LM4Y92oMBl47ilLOGf0xmkCyEjL6U7q6ZQL+yqk/fzn1rYnAkB0e6gTc+y3IWR1NRodkEzNKNY+pWhF1qHSzfH/IQ+MkJSez4dcmdQmwe0c2AiA/RYc1Effdwe8zXXe+YdG2wNaW12WhRd4bKl6VZmvq5we7RYlAENXYby8UcVGoMCifx/dSx7ExGfAs4rGhez9mxDygmHA/VucIh1USORS75gCfnmpOPDL6bWUQLQ2SbC0eaixDRp5svHDQMR08GF0p7N/rLsIjLMm4y1oDIavxDNri4GEfrDXviADd9v8MKfO/JrKEyMIUfEi5+iNLFEdVXRUyAZ5RpbORObofdX3scYWQfUPbgPGr0iaFUmmD/2WuvMnagIMkNnLPJmk0nBDwybl6rfy/M2UUEURXygKgXGq9Q9A5iLgkV5mI25DvZkTuruFtXoYHkS2tAGiVs6cKtaEVAhzLaY9lXYTTZAF+xWpKFv5NQhUmMG0rcYpHooLjPe5t68RhczyplFpUszJ4souePopDGlqjJO7h3u4cz9pRWjGIk6aW4/eFYmbTXqb8Ls75g0JKy0nfnVD87CAMW75InzBZYoIPHOFfwMGQk9BQGwstwZePgsjMix1hc68F5mrjzzIUgmUmyVWbBX7gqfFA/f/+M/YqgUHh1xMx6w2hORW8h9YW4DQMA/459ZlTL+d5laGZYbt/FOQcjT8GYn60yOhn0/LBYo9JRXiEZ2QWOhmrOWiEBFPL3uBnO78dOU4Sg/7gGFXSZxUvnn5SfhwqC3rHpSVH8bcayE9dOsVRx6v4z+g0=
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      creationTimestamp: null
+      name: city-library-strapi-app-keys-secret
+      namespace: standalone
+

--- a/strapi/kubernetes/base/secrets/app-keys.secret.staging.yml
+++ b/strapi/kubernetes/base/secrets/app-keys.secret.staging.yml
@@ -1,0 +1,20 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  creationTimestamp: null
+  name: city-library-strapi-app-keys-secret
+  namespace: standalone
+spec:
+  encryptedData:
+    APP_KEYS: AgBYfuTO/0QPcXWNKl83gCAaUeuddC/xPRSJ349E6NJoW1pFFeytUlJH6hFLPn3mBGiz/vOddiRZ52NbT3rp4pzbUbEIlfQVSTkSsi1y0GJIVQzPpoet0p2A9FrokvpMcJ6VvXd1BAmVV+42/bWtPfnowjSCVCF6G7UsCnHlXYnAUJ9mv0qs+AvNoFYfNmx7yIsvp/DcGEDhl3o/1n6izVh4rjXXWrOiZDXekELd+4JHPX/cNVFuh/jwwaNkVuYTjZLsIMNj/fnEjaTJKANv7sVJCpbP14BdbOvFRIkn8Ny/9JEA7sqv35EWLP1xDHLzd4wt9nRKclu7m33wYi/3Wg78ng7ZpeOBTY02Z/cy4Pyvoz608KzG1SVwUHHf5vwVTKP0qON0bMMR5D+ZThCnlKuSXHB9cr7i6Shji7EeFYxIKAN/cAgRKldTj6sEsijHkkdmefuelYLb//EQApV3Jm3eRNeURm2uMiuoaiOtlwlahuFWVKQ5+ieEBFmmFBMvCKzGaNX3wurR8JvKRHr760o9bjIoPCMcWxDunAT464ye2DSn137krhs/TBh8OMrqHtKg2IyE34ERCsSU+WBGfuFZe/02Cl3XUAHU+eVZBIAJk1boEkC4G2shsLmHLPgXa8EasYkxS99ANBZJ6gxdekpB/TmngqIwlmuei9a47/b0pc/+vW/gXRfTfRODxnHaEQK64dkRoAC6c+IYoQHH1Rfye08skKGY4DRJbuoabiCrJaZ/FEnmfzaUsR2aBU2PsKlh+YZGXeny9V5FLn/7EN5jLmpTItN3iklF1ngb5ArFJM6fqaxjy/cCb1a8YBRM7HJULU4a6bKIOe3XdImNWlfo0WfgZWbt1cer/d72lqdq1Fdra2J/Qj2XSRM66YDzI4CDQF9Fo5qw/qBEFoBg/mqwi2/9wlKQ54MbX/Bxr1tcPw2yMaFvcpvt9TB71XbKo37WKJH8POzg950PuHW8CuatVJC/vb9JjTf4OiV8FooTvRuNap7V1xannDDDE7bSXJbX5J6/
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      creationTimestamp: null
+      name: city-library-strapi-app-keys-secret
+      namespace: standalone
+


### PR DESCRIPTION
Needed to opensource the repo.

A good prerequisite (though not necessarily for other envs) is to make the Strapi run against prod database. APP_KEYS is presently a non-secret env var in our kbs, before each deployment, this env var needs to be removed and make way for the secret one (I don't know how it behaves if there are 2 kbs vars with same name on same pod).

That is - this is prep work but it can't be merged as of yet.