### PR TITLE
Needed changes for meilisearch 

### DIFF
--- a/strapi/kubernetes/base/deployment.yml
+++ b/strapi/kubernetes/base/deployment.yml
@@ -5,6 +5,11 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     service: app
+  annotations:
+    repositoryUrl: ${BUILD_REPOSITORY_URI}
+    commit: ${COMMIT}
+    tag: ${TAG}
+    image: ${IMAGE}
 spec:
   selector:
     matchLabels:

--- a/strapi/kubernetes/base/kustomization.yml
+++ b/strapi/kubernetes/base/kustomization.yml
@@ -21,11 +21,8 @@ commonLabels:
   app: ${BUILD_REPOSITORY_NAME}
   source: ${BUILD_REPOSITORY_NAME}
 
-commonAnnotations:
-  repositoryUrl: ${BUILD_REPOSITORY_URI}
-  commit: ${COMMIT}
-  tag: ${TAG}
-  image: ${IMAGE}
+generatorOptions:
+  disableNameSuffixHash: true
 
 configMapGenerator:
   - name: ${BUILD_REPOSITORY_NAME}-env

--- a/strapi/kubernetes/envs/Dev/kustomization.yml
+++ b/strapi/kubernetes/envs/Dev/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: ${BUILD_REPOSITORY_NAME}-env
     namespace: ${NAMESPACE}

--- a/strapi/kubernetes/envs/Prod/kustomization.yml
+++ b/strapi/kubernetes/envs/Prod/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: ${BUILD_REPOSITORY_NAME}-env
     namespace: ${NAMESPACE}

--- a/strapi/kubernetes/envs/Staging/kustomization.yml
+++ b/strapi/kubernetes/envs/Staging/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: ${BUILD_REPOSITORY_NAME}-env
     namespace: ${NAMESPACE}


### PR DESCRIPTION
this PR is removing all general annotations which are different per deployment, and moving them to deployment.yml only. Also configmap and secret hash are disabled.

We are doing this steps to avoid redeploying statefull sets like meilisearch every time strapi or next is deployed.