### PR TITLE
#348 Adjust the wording of SK and EN error message for ID number field

### DIFF
--- a/next/public/locales/en/forms.json
+++ b/next/public/locales/en/forms.json
@@ -143,7 +143,7 @@
   "password_again": "Password again",
   "validation_error_password_gt_7": "must have at least 7 characters",
   "validation_error_password_mismatch": "must match with Password",
-  "validation_error_idcard": "must be 15 characters or fewer and alphanumeric",
+  "validation_error_idcard": "must contain only letters or numbers and have maximum of 15 characters",
   "generic_error_title": "Error",
   "form_city_accept_newsletter": "I agree to receive news from the online catalogue.",
   "validation_error_captcha": "validation is required.",

--- a/next/public/locales/sk/forms.json
+++ b/next/public/locales/sk/forms.json
@@ -143,7 +143,7 @@
   "password_again": "Heslo opakovane",
   "validation_error_password_gt_7": "musí mať aspoň 7 znakov",
   "validation_error_password_mismatch": "sa musí zhodovať s heslom",
-  "validation_error_idcard": "musí mať tvar AA000000",
+  "validation_error_idcard": "musí obsahovať iba písmená alebo čísla a môže mať maximálne 15 znakov",
   "generic_error_title": "Chyba",
   "form_city_accept_newsletter": "Súhlasím s odoberaním noviniek z online katalógu.",
   "validation_error_captcha": "overenie je potrebné.",


### PR DESCRIPTION
### Description
- Adjust the wording of the error messages as discussed in Slack

### Screenshots
| Slovak | English |
|----------|----------|
| <img width="439" alt="Screenshot 2025-01-20 at 15 10 13" src="https://github.com/user-attachments/assets/4e3474e4-eb70-478b-9139-1ec1cd4609e9" /> | <img width="494" alt="Screenshot 2025-01-20 at 13 38 35" src="https://github.com/user-attachments/assets/36ccfc52-8983-4223-8bbb-ea4fe63bac4e" /> |
