### PR TITLE
#308 Refactor focus ring behaviour

### DIFF
--- a/next/components/AppLayout/Header.tsx
+++ b/next/components/AppLayout/Header.tsx
@@ -23,7 +23,7 @@ const Header = ({ menus }: HeaderProps) => {
           <div>
             <MLink
               href="/"
-              className="flex h-full text-[27px] uppercase leading-[26px] tracking-[0.6px]"
+              className="flex h-full text-[27px] uppercase leading-[26px] tracking-[0.6px] ring-inset ring-offset-0"
             >
               {t('pageTitle')
                 .split(' ')

--- a/next/components/AppLayout/Header.tsx
+++ b/next/components/AppLayout/Header.tsx
@@ -23,6 +23,7 @@ const Header = ({ menus }: HeaderProps) => {
           <div>
             <MLink
               href="/"
+              // Using `ring-inset` because offset doesn't look appealing in this context
               className="flex h-full text-[27px] uppercase leading-[26px] tracking-[0.6px] ring-inset ring-offset-0"
             >
               {t('pageTitle')

--- a/next/components/AppLayout/Navigation/HeaderNavigation.tsx
+++ b/next/components/AppLayout/Navigation/HeaderNavigation.tsx
@@ -15,6 +15,7 @@ const HeaderNavigation = () => {
       <MLink
         href={getPathForStrapiEntity(general?.data?.attributes?.openingHoursPage?.data) ?? '#'}
         variant="basic"
+        // Using `ring-inset` because offset doesn't look appealing in this context
         className="relative grid place-content-center border-l border-border-dark px-3 ring-inset ring-offset-0"
       >
         {t('openingHours')}

--- a/next/components/AppLayout/Navigation/HeaderNavigation.tsx
+++ b/next/components/AppLayout/Navigation/HeaderNavigation.tsx
@@ -15,7 +15,7 @@ const HeaderNavigation = () => {
       <MLink
         href={getPathForStrapiEntity(general?.data?.attributes?.openingHoursPage?.data) ?? '#'}
         variant="basic"
-        className="relative grid place-content-center border-l border-border-dark px-3"
+        className="relative grid place-content-center border-l border-border-dark px-3 ring-inset ring-offset-0"
       >
         {t('openingHours')}
       </MLink>
@@ -23,7 +23,7 @@ const HeaderNavigation = () => {
         href="https://opac.mestskakniznica.sk/opac"
         variant="basic"
         target="_blank"
-        className="grid place-content-center border-l border-border-dark px-3"
+        className="grid place-content-center border-l border-border-dark px-3 ring-inset ring-offset-0"
       >
         {t('onlineCatalog')}
       </MLink>
@@ -32,7 +32,7 @@ const HeaderNavigation = () => {
         locale={otherLocale.locale}
         aria-label={t('otherLocaleAriaLabel')}
         variant="basic"
-        className="grid place-content-center border-l border-border-dark pl-3"
+        className="grid place-content-center border-l border-border-dark pl-3 ring-inset ring-offset-0"
       >
         {otherLocale.locale.toUpperCase()}
       </MLink>

--- a/next/components/Atoms/SelectField.tsx
+++ b/next/components/Atoms/SelectField.tsx
@@ -9,6 +9,7 @@ import { usePopper } from 'react-popper'
 export interface Option {
   key: string
   label: ReactNode | string
+
   [key: string]: unknown
 }
 
@@ -101,7 +102,7 @@ const SelectField = ({
       <Listbox.Button
         ref={setReferenceElement}
         as="button"
-        className="group flex w-full outline-none"
+        className="group flex w-full outline-none ring-offset-2 transition focus-visible:ring"
       >
         {({ open }) => (
           <FieldWrapper

--- a/next/components/Atoms/SelectField.tsx
+++ b/next/components/Atoms/SelectField.tsx
@@ -102,7 +102,7 @@ const SelectField = ({
       <Listbox.Button
         ref={setReferenceElement}
         as="button"
-        className="group flex w-full outline-none ring-offset-2 transition focus-visible:ring"
+        className="base-focus-ring group flex w-full"
       >
         {({ open }) => (
           <FieldWrapper

--- a/next/components/Atoms/TagToggle.tsx
+++ b/next/components/Atoms/TagToggle.tsx
@@ -16,7 +16,7 @@ const TagButton = (props: TagButtonProps) => {
       ref={ref}
       type="button"
       className={cx(
-        'flex h-8 w-fit cursor-pointer select-none items-center whitespace-nowrap rounded-full border px-3 text-sm font-semibold',
+        'base-focus-ring flex h-8 w-fit cursor-pointer select-none items-center whitespace-nowrap rounded-full border px-3 text-sm font-semibold',
         {
           'border-dark bg-dark text-white': isSelected,
           'border-border hover:text-primary bg-white': !isSelected,

--- a/next/components/Atoms/TextField.tsx
+++ b/next/components/Atoms/TextField.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames'
 import { DetailedHTMLProps, InputHTMLAttributes, ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
 
 import FieldWrapper from '../Molecules/FieldWrapper'
 
@@ -90,12 +91,12 @@ const TextField = (props: TextFieldProps) => {
     <FieldWrapper
       id={id}
       label={label}
-      className={className}
       hasLeftSlot={!!leftSlot}
       hasRightSlot={!!rightSlot}
       disabled={disabled}
       error={error}
       required={required}
+      className={twMerge(cx('ring-inset transition focus-within:ring', className))}
     >
       {leftSlot && (
         <div className={cx('shrink-0 grow-0', { 'p-3': isLarge, 'p-2': !isLarge })}>{leftSlot}</div>

--- a/next/components/Atoms/TextField.tsx
+++ b/next/components/Atoms/TextField.tsx
@@ -96,7 +96,7 @@ const TextField = (props: TextFieldProps) => {
       disabled={disabled}
       error={error}
       required={required}
-      className={twMerge(cx('ring-inset transition focus-within:ring', className))}
+      className={twMerge(cx('ring-offset-2 transition focus-within:ring', className))}
     >
       {leftSlot && (
         <div className={cx('shrink-0 grow-0', { 'p-3': isLarge, 'p-2': !isLarge })}>{leftSlot}</div>

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -15,7 +15,7 @@ const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
     <Carousel
       listClassName="my-10 h-[350px] gap-4 px-4 lg:px-0 md:h-[490px] lg:gap-5"
-      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px] focus-within:ring-2 focus-within:ring-outline"
+      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
       shiftIndex={3}
       items={promos
         ?.map((promo) => {

--- a/next/components/Molecules/EventDetails.tsx
+++ b/next/components/Molecules/EventDetails.tsx
@@ -135,7 +135,7 @@ const EventDetails = ({ event }: PageProps) => {
             <div className="pt-5">
               <RichText content={event?.attributes?.description ?? ''} />
             </div>
-            {filteredImages?.length > 0 ? (
+            {filteredImages.length > 0 ? (
               <div className="pt-5">
                 <ImageGallery images={filteredImages} variant="below" />
               </div>

--- a/next/components/Molecules/EventDetails.tsx
+++ b/next/components/Molecules/EventDetails.tsx
@@ -76,6 +76,8 @@ const EventDetails = ({ event }: PageProps) => {
     ...event?.attributes?.coverImage?.data?.attributes,
   }
 
+  const filteredImages = event?.attributes?.gallery?.data?.filter(isDefined) ?? []
+
   return (
     <>
       <img
@@ -133,12 +135,11 @@ const EventDetails = ({ event }: PageProps) => {
             <div className="pt-5">
               <RichText content={event?.attributes?.description ?? ''} />
             </div>
-            <div className="pt-5">
-              <ImageGallery
-                images={event?.attributes?.gallery?.data.filter(isDefined) ?? []}
-                variant="below"
-              />
-            </div>
+            {filteredImages?.length > 0 ? (
+              <div className="pt-5">
+                <ImageGallery images={filteredImages} variant="below" />
+              </div>
+            ) : null}
           </div>
           {event?.attributes?.documents && (
             <Documents

--- a/next/components/forms/FormContainer.tsx
+++ b/next/components/forms/FormContainer.tsx
@@ -90,7 +90,7 @@ const FormContainer = ({
               // eslint-disable-next-line @typescript-eslint/no-misused-promises
               onSubmit={onSubmit}
               onKeyDown={() => listener}
-              className="fixed inset-0 z-40 flex flex-col bg-white outline-none ring-offset-2 transition focus-visible:ring md:relative md:z-0"
+              className="base-focus-ring fixed inset-0 z-40 flex flex-col bg-white md:relative md:z-0"
             >
               {/* HEADER */}
               <div className="flex items-center justify-between border-b border-border-dark md:hidden">

--- a/next/components/forms/FormContainer.tsx
+++ b/next/components/forms/FormContainer.tsx
@@ -83,11 +83,14 @@ const FormContainer = ({
             {buttonText}
           </Button>
           {isFormOpen && (
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
             <form
-              onSubmit={onSubmit}
-              className="fixed inset-0 z-40 flex flex-col bg-white md:relative md:z-0"
-              onKeyDown={() => listener}
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
               tabIndex={0}
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onSubmit={onSubmit}
+              onKeyDown={() => listener}
+              className="fixed inset-0 z-40 flex flex-col bg-white outline-none ring-offset-2 transition focus-visible:ring md:relative md:z-0"
             >
               {/* HEADER */}
               <div className="flex items-center justify-between border-b border-border-dark md:hidden">

--- a/next/components/forms/StepNumberTitle.tsx
+++ b/next/components/forms/StepNumberTitle.tsx
@@ -32,12 +32,9 @@ const StepNumberTitle = ({ num, title, activeStep, onClick, className, children 
       <button
         type="button"
         onClick={onClick}
-        className={cx(
-          'flex cursor-pointer items-center gap-x-6 outline-none ring-offset-2 transition focus-visible:ring',
-          {
-            'mb-6': active || finished,
-          }
-        )}
+        className={cx('base-focus-ring flex cursor-pointer items-center gap-x-6', {
+          'mb-6': active || finished,
+        })}
         aria-label={`${active ? t('openAccordian') : t('closeAccordian')} ${title}`}
       >
         <span

--- a/next/components/forms/StepNumberTitle.tsx
+++ b/next/components/forms/StepNumberTitle.tsx
@@ -32,9 +32,12 @@ const StepNumberTitle = ({ num, title, activeStep, onClick, className, children 
       <button
         type="button"
         onClick={onClick}
-        className={cx('flex cursor-pointer items-center gap-x-6 ', {
-          'mb-6': active || finished,
-        })}
+        className={cx(
+          'flex cursor-pointer items-center gap-x-6 outline-none ring-offset-2 transition focus-visible:ring',
+          {
+            'mb-6': active || finished,
+          }
+        )}
         aria-label={`${active ? t('openAccordian') : t('closeAccordian')} ${title}`}
       >
         <span

--- a/next/components/pages/SearchPage.tsx
+++ b/next/components/pages/SearchPage.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon } from '@assets/icons'
 import { PageTitle, Pagination, SectionContainer } from '@bratislava/ui-city-library'
 import Breadcrumbs from '@modules/breadcrumbs/Breadcrumbs'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import {
   allSearchTypes,
@@ -27,7 +28,7 @@ const SearchPage = () => {
   const { getPathForEntity } = useNavikronos()
   const plausible = usePlausible()
 
-  const resultsRef = useRef<HTMLDivElement>(null)
+  const resultsRef = useRef<HTMLUListElement>(null)
 
   const [filters, setFilters] = useState<CommonSearchFilters>({
     searchValue: '',
@@ -113,22 +114,22 @@ const SearchPage = () => {
           />
         </div>
         <div className="mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
-          <div className="flex w-full items-center gap-3 overflow-auto pb-3 sm:pb-0">
-            <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
-              {t('allResults')}
-            </TagToggle>
+          <ul className="flex w-full items-center gap-3 overflow-auto pb-3 sm:pb-0">
+            <li>
+              <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
+                {t('allResults')}
+              </TagToggle>
+            </li>
             {allSearchTypes.map((type) => {
               return (
-                <TagToggle
-                  isSelected={isTypeSelected(type)}
-                  onChange={changeTypeSelected(type)}
-                  key={type}
-                >
-                  {t(`searchTags.${type}`)}
-                </TagToggle>
+                <li key={type}>
+                  <TagToggle isSelected={isTypeSelected(type)} onChange={changeTypeSelected(type)}>
+                    {t(`searchTags.${type}`)}
+                  </TagToggle>
+                </li>
               )
             })}
-          </div>
+          </ul>
         </div>
 
         <h2 className="sr-only">{t('searchResults')}</h2>
@@ -159,44 +160,39 @@ const SearchPage = () => {
                 {t('resultsFound', { count: 0 })}
               </motion.div>
             ) : (
-              <div ref={resultsRef} className="flex flex-col">
+              <ul ref={resultsRef} className="flex flex-col">
                 {data?.hits.map(({ title, type, id, slug }, index) => {
                   const link = getPathForEntity(
                     type === 'page' ? { type, id: String(id) } : { type, slug }
                   )
 
                   return (
-                    <div
-                      // eslint-disable-next-line react/no-array-index-key
+                    <li // eslint-disable-next-line react/no-array-index-key
                       key={index}
-                      className="group relative flex items-center justify-between gap-x-6 border-b border-border-dark py-4 focus-within:border-transparent focus-within:ring-2 focus-within:ring-outline"
                     >
-                      <div className="flex grow flex-col gap-y-2">
-                        <div className="flex items-start gap-x-4 max-md:justify-between">
-                          <MLink
-                            href={link ?? '#'}
-                            variant="basic"
-                            stretched
-                            className="outline-none"
-                          >
-                            <h2>{title}</h2>
-                          </MLink>
-                          {/* py set to 2px to coun also with the border */}
-                          <span className="flex h-6 shrink-0 items-center rounded-[4px] border border-dark px-2 py-[3px] text-[12px] leading-[18px]">
-                            {/* TODO proper translation keys */}
-                            {t(`searchTags.${type}`)}
-                          </span>
+                      <CardWrapper className="group relative flex items-center justify-between gap-x-6 border-b border-border-dark py-4">
+                        <div className="flex grow flex-col gap-y-2">
+                          <div className="flex items-start gap-x-4 max-md:justify-between">
+                            <MLink href={link ?? '#'} variant="basic" stretched>
+                              <h2>{title}</h2>
+                            </MLink>
+                            {/* py set to 2px to coun also with the border */}
+                            <span className="flex h-6 shrink-0 items-center rounded-[4px] border border-dark px-2 py-[3px] text-[12px] leading-[18px]">
+                              {/* TODO proper translation keys */}
+                              {t(`searchTags.${type}`)}
+                            </span>
+                          </div>
+                          <div className="flex items-center text-xs text-foreground-body">
+                            <span>{link}</span>
+                          </div>
                         </div>
-                        <div className="flex items-center text-xs text-foreground-body">
-                          <span>{link}</span>
-                        </div>
-                      </div>
 
-                      <ChevronRightIcon className="shrink-0 max-md:hidden" />
-                    </div>
+                        <ChevronRightIcon className="shrink-0 max-md:hidden" />
+                      </CardWrapper>
+                    </li>
                   )
                 })}
-              </div>
+              </ul>
             )}
           </AnimateHeight>
           {data?.estimatedTotalHits ? (

--- a/next/components/ui/CheckBox/CheckBox.tsx
+++ b/next/components/ui/CheckBox/CheckBox.tsx
@@ -22,7 +22,7 @@ export const CheckBox = ({ className, children, ...props }: CheckBoxProps) => {
         id={props.id}
         required={props.required}
         className={cx(
-          'flex-0 box-border flex h-5 w-5 items-center justify-center overflow-hidden border-2 border-border-dark text-white outline-1 outline-offset-2 focus:outline',
+          'flex-0 box-border flex h-5 w-5 items-center justify-center overflow-hidden border-2 border-border-dark text-white outline-none ring-offset-2 transition focus-visible:ring',
           {
             'bg-dark': props.checked,
             'base-input--disabled': props.disabled,

--- a/next/components/ui/CheckBox/CheckBox.tsx
+++ b/next/components/ui/CheckBox/CheckBox.tsx
@@ -22,7 +22,7 @@ export const CheckBox = ({ className, children, ...props }: CheckBoxProps) => {
         id={props.id}
         required={props.required}
         className={cx(
-          'flex-0 box-border flex h-5 w-5 items-center justify-center overflow-hidden border-2 border-border-dark text-white outline-none ring-offset-2 transition focus-visible:ring',
+          'base-focus-ring flex-0 box-border flex h-5 w-5 items-center justify-center overflow-hidden border-2 border-border-dark text-white',
           {
             'bg-dark': props.checked,
             'base-input--disabled': props.disabled,

--- a/next/components/ui/Footer/Footer.tsx
+++ b/next/components/ui/Footer/Footer.tsx
@@ -36,8 +36,7 @@ const FooterLinks = ({
           key={link.id}
           href={link.otherSite || getPathForStrapiEntity(link.redirectTo?.data) || '#'}
           variant="basic"
-          // `ring-inset` and `ring-offset-0` were used for visual reasons
-          className="text-base text-foreground-body ring-inset ring-offset-0"
+          className="text-base text-foreground-body"
         >
           {link.title}
         </MLink>
@@ -85,6 +84,7 @@ export const Footer = ({
             href={facebookUrl}
             target="_blank"
             rel="noreferrer"
+            // `ring-inset` and `ring-offset-0` were used for visual reasons
             className="flex h-full items-center justify-center ring-inset ring-offset-0"
           >
             <FbLogo className="cursor-pointer lg:p-0" />

--- a/next/components/ui/Footer/Footer.tsx
+++ b/next/components/ui/Footer/Footer.tsx
@@ -36,7 +36,8 @@ const FooterLinks = ({
           key={link.id}
           href={link.otherSite || getPathForStrapiEntity(link.redirectTo?.data) || '#'}
           variant="basic"
-          className="text-base text-foreground-body"
+          // `ring-inset` and `ring-offset-0` were used for visual reasons
+          className="text-base text-foreground-body ring-inset ring-offset-0"
         >
           {link.title}
         </MLink>
@@ -84,7 +85,7 @@ export const Footer = ({
             href={facebookUrl}
             target="_blank"
             rel="noreferrer"
-            className="flex h-full items-center justify-center"
+            className="flex h-full items-center justify-center ring-inset ring-offset-0"
           >
             <FbLogo className="cursor-pointer lg:p-0" />
             <span className="sr-only">Facebook</span>
@@ -93,7 +94,7 @@ export const Footer = ({
             href={instagramUrl}
             target="_blank"
             rel="noreferrer"
-            className="flex h-full items-center justify-center border-x border-border-dark"
+            className="flex h-full items-center justify-center border-x border-border-dark ring-inset ring-offset-0"
           >
             <IgLogo className="cursor-pointer lg:p-0" />
             <span className="sr-only">Instagram</span>
@@ -102,7 +103,7 @@ export const Footer = ({
             href={youtubeUrl}
             target="_blank"
             rel="noreferrer"
-            className="flex h-full items-center justify-center"
+            className="flex h-full items-center justify-center ring-inset ring-offset-0"
           >
             <YtLogo className="cursor-pointer lg:p-0" />
             <span className="sr-only">Youtube</span>

--- a/next/components/ui/Footer/Footer.tsx
+++ b/next/components/ui/Footer/Footer.tsx
@@ -84,7 +84,7 @@ export const Footer = ({
             href={facebookUrl}
             target="_blank"
             rel="noreferrer"
-            // `ring-inset` and `ring-offset-0` were used for visual reasons
+            // Using `ring-inset` because offset doesn't look appealing in this context
             className="flex h-full items-center justify-center ring-inset ring-offset-0"
           >
             <FbLogo className="cursor-pointer lg:p-0" />

--- a/next/components/ui/Input/Input.tsx
+++ b/next/components/ui/Input/Input.tsx
@@ -55,7 +55,7 @@ export const Input = ({
         <input
           id={id}
           className={cx(
-            'base-input outline-none ring-inset transition focus-visible:ring',
+            'base-input outline-none ring-offset-2 transition focus-visible:ring',
             inputClassName,
             {
               'base-input--disabled cursor-not-allowed text-foreground-disabled': props.disabled,

--- a/next/components/ui/Input/Input.tsx
+++ b/next/components/ui/Input/Input.tsx
@@ -54,10 +54,14 @@ export const Input = ({
         {/* BaseInput */}
         <input
           id={id}
-          className={cx('base-input', inputClassName, {
-            'base-input--disabled cursor-not-allowed text-foreground-disabled': props.disabled,
-            'base-input--with-error': hasError,
-          })}
+          className={cx(
+            'base-input outline-none ring-inset transition focus-visible:ring',
+            inputClassName,
+            {
+              'base-input--disabled cursor-not-allowed text-foreground-disabled': props.disabled,
+              'base-input--with-error': hasError,
+            }
+          )}
           aria-invalid={hasError}
           aria-required={required}
           aria-errormessage={errorMessage ? `${id ?? ''}_err` : undefined}

--- a/next/components/ui/Input/Input.tsx
+++ b/next/components/ui/Input/Input.tsx
@@ -54,14 +54,10 @@ export const Input = ({
         {/* BaseInput */}
         <input
           id={id}
-          className={cx(
-            'base-input outline-none ring-offset-2 transition focus-visible:ring',
-            inputClassName,
-            {
-              'base-input--disabled cursor-not-allowed text-foreground-disabled': props.disabled,
-              'base-input--with-error': hasError,
-            }
-          )}
+          className={cx('base-input base-focus-ring', inputClassName, {
+            'base-input--disabled cursor-not-allowed text-foreground-disabled': props.disabled,
+            'base-input--with-error': hasError,
+          })}
           aria-invalid={hasError}
           aria-required={required}
           aria-errormessage={errorMessage ? `${id ?? ''}_err` : undefined}

--- a/next/components/ui/Link/Link.tsx
+++ b/next/components/ui/Link/Link.tsx
@@ -23,17 +23,13 @@ export const Link = ({
   return (
     <NextLink
       href={href}
-      className={cx(
-        'outline-none ring-offset-2 transition hover:underline focus-visible:ring',
-        className,
-        {
-          'flex items-center gap-x-2.5 text-foreground-heading': variant === 'default',
-          'text-[16px]': size === 'large',
-          'text-[14px]': size === 'default',
-          'text-[12px]': size === 'small',
-          uppercase,
-        }
-      )}
+      className={cx('base-focus-ring hover:underline', className, {
+        'flex items-center gap-x-2.5 text-foreground-heading': variant === 'default',
+        'text-[16px]': size === 'large',
+        'text-[14px]': size === 'default',
+        'text-[12px]': size === 'small',
+        uppercase,
+      })}
       {...props}
     >
       {children}

--- a/next/components/ui/Link/Link.tsx
+++ b/next/components/ui/Link/Link.tsx
@@ -23,13 +23,17 @@ export const Link = ({
   return (
     <NextLink
       href={href}
-      className={cx('hover:underline', className, {
-        'flex items-center gap-x-2.5 text-foreground-heading': variant === 'default',
-        'text-[16px]': size === 'large',
-        'text-[14px]': size === 'default',
-        'text-[12px]': size === 'small',
-        uppercase,
-      })}
+      className={cx(
+        'outline-none ring-offset-2 transition hover:underline focus-visible:ring',
+        className,
+        {
+          'flex items-center gap-x-2.5 text-foreground-heading': variant === 'default',
+          'text-[16px]': size === 'large',
+          'text-[14px]': size === 'default',
+          'text-[12px]': size === 'small',
+          uppercase,
+        }
+      )}
       {...props}
     >
       {children}

--- a/next/components/ui/MapSection/MapSection.tsx
+++ b/next/components/ui/MapSection/MapSection.tsx
@@ -1,6 +1,7 @@
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import MarkerIcon from '@assets/images/marker.svg'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import { BranchCardEntityFragment } from '@services/graphql'
@@ -140,21 +141,22 @@ const MapSection = ({ branches, mapboxAccessToken, title, altDesign = false }: M
             const linkHref = getPathForStrapiEntity(branch) ?? '#'
 
             return (
-              <div
-                className={cx('relative focus-within:ring-2 focus-within:ring-outline', {
+              <CardWrapper
+                key={branch.id}
+                // `ring-inset` was used instead of the default `ring-offset-2` for visual reasons
+                className={cx('relative ring-inset', {
                   'lg:border-l-0': index === 0 && !altDesign,
                   'w-70 flex-shrink-0 border border-border-dark lg:mb-6 lg:w-auto lg:flex-1 lg:border-r-0 lg:border-t-0 lg:border-b-0 lg:focus-within:border-transparent':
                     !altDesign,
                   'w-full border border-border-dark py-4': altDesign,
                 })}
-                key={branch.id}
               >
                 {/* TODO move link to title */}
 
                 <div className="group/showMore flex h-full w-full flex-col justify-between gap-8 p-6 lg:py-0">
                   <div>
                     <div className="text-h3">
-                      <MLink href={linkHref} variant="basic" stretched className="outline-none">
+                      <MLink href={linkHref} variant="basic" stretched>
                         {title}
                       </MLink>
                     </div>
@@ -178,7 +180,7 @@ const MapSection = ({ branches, mapboxAccessToken, title, altDesign = false }: M
                     {t('homepage:localityDetailText')}
                   </ShowMoreLink>
                 </div>
-              </div>
+              </CardWrapper>
             )
           })}
         </div>

--- a/next/components/ui/MapSection/MapSection.tsx
+++ b/next/components/ui/MapSection/MapSection.tsx
@@ -143,8 +143,7 @@ const MapSection = ({ branches, mapboxAccessToken, title, altDesign = false }: M
             return (
               <CardWrapper
                 key={branch.id}
-                // `ring-inset` was used instead of the default `ring-offset-2` for visual reasons
-                className={cx('relative ring-inset', {
+                className={cx('relative', {
                   'lg:border-l-0': index === 0 && !altDesign,
                   'w-70 flex-shrink-0 border border-border-dark lg:mb-6 lg:w-auto lg:flex-1 lg:border-r-0 lg:border-t-0 lg:border-b-0 lg:focus-within:border-transparent':
                     !altDesign,

--- a/next/components/ui/RadioGroup/RadioGroup.tsx
+++ b/next/components/ui/RadioGroup/RadioGroup.tsx
@@ -82,7 +82,7 @@ export const RadioGroup = <T extends IRadioOption>({
                   <RadioGroupPrimitive.Item
                     value={opt.key}
                     id={opt.key}
-                    className="box-border flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border-2 border-border-dark "
+                    className="box-border flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border-2 border-border-dark outline-none ring-offset-2 transition focus-visible:ring"
                   >
                     <RadioGroupPrimitive.Indicator className="h-3 w-3 rounded-full bg-dark" />
                   </RadioGroupPrimitive.Item>

--- a/next/components/ui/RadioGroup/RadioGroup.tsx
+++ b/next/components/ui/RadioGroup/RadioGroup.tsx
@@ -82,7 +82,7 @@ export const RadioGroup = <T extends IRadioOption>({
                   <RadioGroupPrimitive.Item
                     value={opt.key}
                     id={opt.key}
-                    className="box-border flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border-2 border-border-dark outline-none ring-offset-2 transition focus-visible:ring"
+                    className="base-focus-ring box-border flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border-2 border-border-dark"
                   >
                     <RadioGroupPrimitive.Indicator className="h-3 w-3 rounded-full bg-dark" />
                   </RadioGroupPrimitive.Item>

--- a/next/components/ui/Select/Select.tsx
+++ b/next/components/ui/Select/Select.tsx
@@ -62,9 +62,12 @@ export const Select = <T extends ISelectOption>({
         <select
           id={id}
           className={twMerge(
-            cx('base-input w-full cursor-pointer pr-9', {
-              'base-input--with-error': hasError,
-            }),
+            cx(
+              'base-input w-full cursor-pointer pr-9 outline-none ring-inset transition focus-visible:ring',
+              {
+                'base-input--with-error': hasError,
+              }
+            ),
             selectClassName
           )}
           onChange={handleChange}

--- a/next/components/ui/Select/Select.tsx
+++ b/next/components/ui/Select/Select.tsx
@@ -62,12 +62,9 @@ export const Select = <T extends ISelectOption>({
         <select
           id={id}
           className={twMerge(
-            cx(
-              'base-input w-full cursor-pointer pr-9 outline-none ring-offset-2 transition focus-visible:ring',
-              {
-                'base-input--with-error': hasError,
-              }
-            ),
+            cx('base-input base-focus-ring w-full cursor-pointer pr-9', {
+              'base-input--with-error': hasError,
+            }),
             selectClassName
           )}
           onChange={handleChange}

--- a/next/components/ui/Select/Select.tsx
+++ b/next/components/ui/Select/Select.tsx
@@ -63,7 +63,7 @@ export const Select = <T extends ISelectOption>({
           id={id}
           className={twMerge(
             cx(
-              'base-input w-full cursor-pointer pr-9 outline-none ring-inset transition focus-visible:ring',
+              'base-input w-full cursor-pointer pr-9 outline-none ring-offset-2 transition focus-visible:ring',
               {
                 'base-input--with-error': hasError,
               }

--- a/next/components/ui/TextArea/TextArea.tsx
+++ b/next/components/ui/TextArea/TextArea.tsx
@@ -34,13 +34,9 @@ export const TextArea = ({
       <div>
         <textarea
           id={id}
-          className={cx(
-            'base-input resize-none outline-none ring-offset-2 transition focus-visible:ring',
-            textAreaClassname,
-            {
-              'base-input--with-error': hasError,
-            }
-          )}
+          className={cx('base-input base-focus-ring resize-none', textAreaClassname, {
+            'base-input--with-error': hasError,
+          })}
           aria-invalid={hasError}
           aria-required={required}
           aria-errormessage={errorMessage ? `${id ?? ''}_err` : undefined}

--- a/next/components/ui/TextArea/TextArea.tsx
+++ b/next/components/ui/TextArea/TextArea.tsx
@@ -35,7 +35,7 @@ export const TextArea = ({
         <textarea
           id={id}
           className={cx(
-            'base-input resize-none outline-none ring-inset transition focus-visible:ring',
+            'base-input resize-none outline-none ring-offset-2 transition focus-visible:ring',
             textAreaClassname,
             {
               'base-input--with-error': hasError,

--- a/next/components/ui/TextArea/TextArea.tsx
+++ b/next/components/ui/TextArea/TextArea.tsx
@@ -34,9 +34,13 @@ export const TextArea = ({
       <div>
         <textarea
           id={id}
-          className={cx('base-input resize-none', textAreaClassname, {
-            'base-input--with-error': hasError,
-          })}
+          className={cx(
+            'base-input resize-none outline-none ring-inset transition focus-visible:ring',
+            textAreaClassname,
+            {
+              'base-input--with-error': hasError,
+            }
+          )}
           aria-invalid={hasError}
           aria-required={required}
           aria-errormessage={errorMessage ? `${id ?? ''}_err` : undefined}

--- a/next/components/ui/Upload/Upload.tsx
+++ b/next/components/ui/Upload/Upload.tsx
@@ -33,7 +33,7 @@ export const Upload = ({
       )}
       <div
         className={cx(
-          'group relative flex flex-col items-center justify-center gap-y-6 border border-dashed p-6 ring-inset transition focus-within:ring',
+          'group relative flex flex-col items-center justify-center gap-y-6 border border-dashed p-6 ring-offset-2 transition focus-within:ring',
           {
             'bg-emerald-200 transform transition-all duration-200':
               isInArea || fileInputRef.current?.files?.length,

--- a/next/components/ui/Upload/Upload.tsx
+++ b/next/components/ui/Upload/Upload.tsx
@@ -33,7 +33,7 @@ export const Upload = ({
       )}
       <div
         className={cx(
-          'group relative flex flex-col items-center justify-center gap-y-6 border border-dashed p-6',
+          'group relative flex flex-col items-center justify-center gap-y-6 border border-dashed p-6 ring-inset transition focus-within:ring',
           {
             'bg-emerald-200 transform transition-all duration-200':
               isInArea || fileInputRef.current?.files?.length,
@@ -48,7 +48,7 @@ export const Upload = ({
           id={id}
           ref={fileInputRef}
           type="file"
-          className="absolute h-full w-full cursor-pointer opacity-0"
+          className="absolute h-full w-full cursor-pointer opacity-0 outline-none"
           aria-invalid={hasError}
           aria-required={required}
           aria-errormessage={errorMessage ? `${id ?? ''}_err` : undefined}

--- a/next/modules/breadcrumbs/BreadcrumbItem.tsx
+++ b/next/modules/breadcrumbs/BreadcrumbItem.tsx
@@ -13,11 +13,7 @@ const BreadcrumbItem = ({ url, isMobile = false, ...rest }: BreadcrumbItemProps)
 
   return (
     // min-w-0 https://css-tricks.com/flexbox-truncated-text/#aa-the-solution-is-min-width-0-on-the-flex-child
-    <li
-      className={`flex min-w-0 list-none items-center focus:ring-2 focus:ring-outline ${
-        !rest.isCurrent ? 'shrink-0' : ''
-      }`}
-    >
+    <li className={`flex min-w-0 list-none items-center ${!rest.isCurrent ? 'shrink-0' : ''}`}>
       {url && !rest.isCurrent ? (
         <MLink
           href={url}

--- a/next/modules/cards-and-rows/BlogPostCard.tsx
+++ b/next/modules/cards-and-rows/BlogPostCard.tsx
@@ -1,4 +1,5 @@
 import Placeholder from '@assets/images/list-item-thumbnail.jpeg'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import FormatDate from '@modules/formatting/FormatDate'
@@ -19,7 +20,7 @@ const BlogPostCard = ({ blogPost }: BlogPostProps) => {
   const link = getPathForStrapiEntity(blogPost)
 
   return (
-    <div className="group/showMore relative flex h-full w-full shrink-0 flex-col justify-between">
+    <CardWrapper className="group/showMore relative flex h-full w-full shrink-0 flex-col justify-between">
       <div className="flex h-full flex-col">
         {/* TODO: Replace with MImage */}
         <img
@@ -40,7 +41,7 @@ const BlogPostCard = ({ blogPost }: BlogPostProps) => {
       <ShowMoreLink href={link ?? ''} tabIndex={-1} parentGroup>
         {t('showMore')}
       </ShowMoreLink>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/BookCard.tsx
+++ b/next/modules/cards-and-rows/BookCard.tsx
@@ -1,3 +1,4 @@
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import cx from 'classnames'
 import Image from 'next/image'
@@ -20,7 +21,7 @@ const BookCard = ({ book }: BookProps) => {
   const hasCover = Boolean(book.coverUrl)
 
   return (
-    <div className="relative flex w-[126px] flex-col gap-2 focus-within:ring-2 focus-within:ring-outline md:w-[180px] md:gap-4">
+    <CardWrapper className="relative flex w-[126px] flex-col gap-2 md:w-[180px] md:gap-4">
       <div
         className={cx('relative h-[162px] w-full overflow-hidden md:h-[232px]', {
           'select-none border border-border-dark pt-3 pl-4 text-[32px] uppercase': !hasCover,
@@ -46,13 +47,13 @@ const BookCard = ({ book }: BookProps) => {
           // Most of the books titles are two lines long, so we fix the height constant to avoid layout shifts when there
           // happens to be row with only single column book titles.
           // The default line height is leading-6, but if that changes this will break, so it's set to be sure.
-          className="outline-none line-clamp-2 md:h-[48px] md:leading-6"
+          className="line-clamp-2 md:h-[48px] md:leading-6"
           target="_blank"
         >
           {book.title}
         </MLink>
       </h3>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/BranchCard.tsx
+++ b/next/modules/cards-and-rows/BranchCard.tsx
@@ -1,3 +1,4 @@
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import { UploadImageEntityFragment } from '@services/graphql'
@@ -18,7 +19,7 @@ const BranchCard = ({ title, address, pageId, image }: BranchCardProps) => {
   const href = (pageId ? getPathForEntity({ type: 'page', id: pageId }) : null) ?? '#'
 
   return (
-    <div className="group/showMore relative flex w-full flex-col">
+    <CardWrapper className="group/showMore relative flex w-full flex-col">
       <img
         src={image?.attributes?.url ?? '#'}
         alt={image?.attributes?.alternativeText ?? ''}
@@ -37,7 +38,7 @@ const BranchCard = ({ title, address, pageId, image }: BranchCardProps) => {
           {t('showMore')}
         </ShowMoreLink>
       </div>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/CardWrapper.tsx
+++ b/next/modules/cards-and-rows/CardWrapper.tsx
@@ -1,0 +1,30 @@
+import cx from 'classnames'
+import { HTMLAttributes, ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+type CardWrapperProps = {
+  children: ReactNode
+  className?: string
+} & HTMLAttributes<HTMLDivElement>
+
+/**
+ * Handles focus styles to achieve a consistent look of focus rings across the app
+ */
+const CardWrapper = ({ children, className }: CardWrapperProps) => {
+  return (
+    <div
+      className={twMerge(
+        cx(
+          // When the card is focused, hide all its descendants’ focus rings (= focus rings of any links within the card) except the card’s focus ring
+          // This needs revisiting when we need more focusable elements in a card
+          'outline-none ring-offset-2 transition focus-within:[&:has(:focus-visible)]:ring [&_*]:outline-none [&_*]:ring-transparent [&_a]:ring-offset-transparent',
+          className
+        )
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default CardWrapper

--- a/next/modules/cards-and-rows/DocumentRow.tsx
+++ b/next/modules/cards-and-rows/DocumentRow.tsx
@@ -1,4 +1,5 @@
 import ChevronRight from '@assets/images/chevron-right.svg'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import FileExtBadge from '@modules/common/FileExtBadge'
 import MLink from '@modules/common/MLink'
 import FormatDate from '@modules/formatting/FormatDate'
@@ -25,7 +26,7 @@ const DocumentRow = ({
   const { t } = useTranslation('common')
 
   return (
-    <div className="group/showMore relative flex gap-5 border-b border-border-dark py-4 pr-2 text-foreground-body lg:gap-8">
+    <CardWrapper className="group/showMore relative flex gap-5 border-b border-border-dark py-4 pr-2 text-foreground-body lg:gap-8">
       <FileExtBadge className="hidden lg:flex" fileExt={fileExt} />
       <div className="flex w-8 shrink-0 self-center text-xs lg:hidden">{fileExt}</div>
 
@@ -47,7 +48,7 @@ const DocumentRow = ({
         </div>
       </div>
       <ChevronRight className="mt-1.5 hidden shrink-0 lg:block" />
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/EventCard.tsx
+++ b/next/modules/cards-and-rows/EventCard.tsx
@@ -1,5 +1,6 @@
 import Placeholder from '@assets/images/list-item-thumbnail.jpeg'
 import TagsDisplay from '@components/Atoms/TagsDisplay'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import FormatEventDateRange from '@modules/formatting/FormatEventDateRange'
 import {
@@ -37,9 +38,9 @@ const EventCard = ({
 }: EventCardProps) => {
   const { t } = useTranslation('common')
   const { getPathForEntity } = useNavikronos()
-
+  
   return (
-    <div className="relative">
+    <CardWrapper className="relative">
       <img
         className="h-[200px] w-full flex-1 object-cover"
         alt={t('eventDetailImagePlaceholder')}
@@ -75,7 +76,7 @@ const EventCard = ({
       {branch?.title && (
         <div className="pt-2 text-sm text-foreground-body">&#9679; {branch.title}</div>
       )}
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/EventRow.tsx
+++ b/next/modules/cards-and-rows/EventRow.tsx
@@ -1,4 +1,5 @@
 import EventDetailsDateBox from '@components/Atoms/EventDetailsDateBox'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import FormatEventDateRange from '@modules/formatting/FormatEventDateRange'
 import { EventCardEntityFragment } from '@services/graphql'
@@ -25,7 +26,7 @@ const EventRow = ({ event }: EventRowProps) => {
   const eventBranchTitle = branch?.data?.attributes?.title
 
   return (
-    <li className="relative flex items-center gap-x-5 py-[14px]">
+    <CardWrapper className="relative flex items-center gap-x-5 py-[14px]">
       <div className="flex h-16 w-16 shrink-0 bg-promo-yellow text-center">
         <EventDetailsDateBox dateFrom={dateFrom} dateTo={dateTo} textClassname="text-[18px]" />
       </div>
@@ -48,7 +49,7 @@ const EventRow = ({ event }: EventRowProps) => {
           )}
         </div>
       </div>
-    </li>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/NoticeCard.tsx
+++ b/next/modules/cards-and-rows/NoticeCard.tsx
@@ -1,4 +1,5 @@
 import Placeholder from '@assets/images/list-item-thumbnail.jpeg'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import FormatDate from '@modules/formatting/FormatDate'
@@ -25,7 +26,7 @@ const NoticeCard = ({ notice }: NoticeCardProps) => {
   }, [notice, t])
 
   return (
-    <div className="group/showMore relative flex h-full w-full shrink-0 flex-col justify-between focus-within:ring-2 focus-within:ring-outline">
+    <CardWrapper className="group/showMore relative flex h-full w-full shrink-0 flex-col justify-between">
       <div className="flex h-full flex-col">
         {/* TODO: Replace with MImage */}
         <img
@@ -38,7 +39,7 @@ const NoticeCard = ({ notice }: NoticeCardProps) => {
           <FormatDate value={date} valueType="ISO" />
         </div>
         <h3 className="mb-6 text-h5">
-          <MLink href={link ?? '#'} variant="basic" stretched className="outline-none line-clamp-3">
+          <MLink href={link ?? '#'} variant="basic" stretched className="line-clamp-3">
             {notice.attributes?.title}
           </MLink>
         </h3>
@@ -46,7 +47,7 @@ const NoticeCard = ({ notice }: NoticeCardProps) => {
       <ShowMoreLink href={link ?? '#'} tabIndex={-1} parentGroup>
         {t('showMore')}
       </ShowMoreLink>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/PageCard.tsx
+++ b/next/modules/cards-and-rows/PageCard.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon } from '@assets/icons'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import cx from 'classnames'
@@ -13,10 +14,10 @@ type PageCardProps = {
 
 const PageCard = ({ className, title, href, showMoreText }: PageCardProps) => {
   return (
-    <div className="group/showMore relative border border-border-dark focus-within:border-solid focus-within:ring-2 focus-within:ring-outline">
+    <CardWrapper className="group/showMore relative border border-border-dark">
       <div className={cx('relative flex flex-col space-y-4 p-4', className)}>
         <div className="h-full overflow-hidden text-[20px]">
-          <MLink href={href} variant="basic" stretched className="outline-none">
+          <MLink href={href} variant="basic" stretched>
             {title}
           </MLink>
         </div>
@@ -32,7 +33,7 @@ const PageCard = ({ className, title, href, showMoreText }: PageCardProps) => {
           </div>
         )}
       </div>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/PartnerCardRow.tsx
+++ b/next/modules/cards-and-rows/PartnerCardRow.tsx
@@ -1,4 +1,5 @@
 import { GlobeIcon } from '@assets/icons'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import cx from 'classnames'
 import { useTranslation } from 'next-i18next'
@@ -14,7 +15,7 @@ type PartnerCardRowProps = {
 const PartnerCardRow = ({ title, id, linkHref, logo, featured = false }: PartnerCardRowProps) => {
   const { t } = useTranslation('common')
   return (
-    <li
+    <CardWrapper
       className={cx('relative flex w-full border-border-dark py-4 lg:p-5', {
         'min-h-[199px] flex-col items-center justify-end border': featured,
         'flex-row justify-between border-b last:border-0 lg:border lg:last:border': !featured,
@@ -62,7 +63,7 @@ const PartnerCardRow = ({ title, id, linkHref, logo, featured = false }: Partner
           </span>
         </MLink>
       </div>
-    </li>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/PromoEventCard.tsx
+++ b/next/modules/cards-and-rows/PromoEventCard.tsx
@@ -1,5 +1,6 @@
 import EventDetailsDateBox from '@components/Atoms/EventDetailsDateBox'
 import TagsDisplay from '@components/Atoms/TagsDisplay'
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import FormatEventDateRange from '@modules/formatting/FormatEventDateRange'
 import { EventCardEntityFragment } from '@services/graphql'
@@ -24,7 +25,7 @@ const PromoEventCard = ({ event }: PromoEventCardProps) => {
   const eventBranch = branch?.data?.attributes
 
   return (
-    <div className="relative m-auto flex h-full w-full flex-col justify-between bg-promo-yellow">
+    <CardWrapper className="relative m-auto flex h-full w-full flex-col justify-between bg-promo-yellow">
       <div className="flex flex-col gap-y-3 py-3 px-4 md:gap-y-4 md:py-4 md:px-5">
         <TagsDisplay
           tags={eventTags?.data
@@ -39,7 +40,7 @@ const PromoEventCard = ({ event }: PromoEventCardProps) => {
             href={getPathForStrapiEntity(event) ?? '#'}
             variant="basic"
             stretched
-            className="outline-none line-clamp-3 after:z-[1]"
+            className="line-clamp-3 after:z-[1]"
           >
             {title}
           </MLink>
@@ -89,7 +90,7 @@ const PromoEventCard = ({ event }: PromoEventCardProps) => {
           )
         )}
       </div>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/cards-and-rows/PromoNewsCard.tsx
+++ b/next/modules/cards-and-rows/PromoNewsCard.tsx
@@ -1,3 +1,4 @@
+import CardWrapper from '@modules/cards-and-rows/CardWrapper'
 import MLink from '@modules/common/MLink'
 import ShowMoreLink from '@modules/common/ShowMoreLink'
 import { NoticeListingEntityFragment } from '@services/graphql'
@@ -16,7 +17,7 @@ const PromoNewsCard = ({ notice }: PromoNewsCardProps) => {
   const link = getPathForStrapiEntity(notice) ?? '#'
 
   return (
-    <div className="group/showMore relative flex h-full w-full flex-col justify-between bg-promo-peach py-3 pl-4 pr-5 lg:pr-[25px] lg:pl-5 lg:pb-[15px] lg:pt-[18px]">
+    <CardWrapper className="group/showMore relative flex h-full w-full flex-col justify-between bg-promo-peach py-3 pl-4 pr-5 lg:pr-[25px] lg:pl-5 lg:pb-[15px] lg:pt-[18px]">
       <h3 className="text-h2">
         <MLink href={link} variant="basic" stretched className="outline-none line-clamp-3">
           {notice.attributes?.title}
@@ -26,7 +27,7 @@ const PromoNewsCard = ({ notice }: PromoNewsCardProps) => {
       <ShowMoreLink href={link} tabIndex={-1} parentGroup>
         {t('showMore')}
       </ShowMoreLink>
-    </div>
+    </CardWrapper>
   )
 }
 

--- a/next/modules/common/Accordion.tsx
+++ b/next/modules/common/Accordion.tsx
@@ -33,13 +33,16 @@ const Accordion = ({ type, title, additionalInfo, children, iconLeft }: Accordio
     'text-sm': type === 'breadcrumbs',
   })
 
-  const buttonStyles = cx('hover:text-underline flex items-center gap-4 text-left text-h5', {
-    'py-[18.5px] px-4 md:px-6 md:py-5': type === 'boxed',
-    'py-[18.5px] md:py-6': type === 'divider-big',
-    'py-[14.5px] md:py-[18.5px]': type === 'divider-small',
-    'py-4': type === 'subbranch',
-    'p-4 -mx-4': type === 'breadcrumbs',
-  })
+  const buttonStyles = cx(
+    'hover:text-underline flex items-center gap-4 text-left text-h5 outline-none ring-offset-2 transition focus-visible:ring',
+    {
+      'py-[18.5px] px-4 md:px-6 md:py-5': type === 'boxed',
+      'py-[18.5px] md:py-6': type === 'divider-big',
+      'py-[14.5px] md:py-[18.5px]': type === 'divider-small',
+      'py-4': type === 'subbranch',
+      'p-4 -mx-4': type === 'breadcrumbs',
+    }
+  )
 
   const leftIconStyles = cx('mr-0 shrink-0 md:mr-2', {
     'bg-yellow grid h-10 w-10 place-content-center bg-promo-yellow md:h-14 md:w-14':

--- a/next/modules/common/Accordion.tsx
+++ b/next/modules/common/Accordion.tsx
@@ -34,7 +34,7 @@ const Accordion = ({ type, title, additionalInfo, children, iconLeft }: Accordio
   })
 
   const buttonStyles = cx(
-    'hover:text-underline flex items-center gap-4 text-left text-h5 outline-none ring-offset-2 transition focus-visible:ring',
+    'hover:text-underline base-focus-ring flex items-center gap-4 text-left text-h5',
     {
       'py-[18.5px] px-4 md:px-6 md:py-5': type === 'boxed',
       'py-[18.5px] md:py-6': type === 'divider-big',

--- a/next/modules/common/Button.tsx
+++ b/next/modules/common/Button.tsx
@@ -72,7 +72,7 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
       ref as RefObject<HTMLAnchorElement | HTMLButtonElement>
     )
 
-    const baseStyle = 'appearance-none outline-1 outline-offset-2 focus:outline'
+    const baseStyle = 'appearance-none outline-none transition focus-visible:ring ring-offset-2'
 
     const style =
       variant === 'unstyled'

--- a/next/modules/common/Button.tsx
+++ b/next/modules/common/Button.tsx
@@ -72,7 +72,7 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
       ref as RefObject<HTMLAnchorElement | HTMLButtonElement>
     )
 
-    const baseStyle = 'appearance-none outline-none transition focus-visible:ring ring-offset-2'
+    const baseStyle = 'appearance-none base-focus-ring'
 
     const style =
       variant === 'unstyled'

--- a/next/modules/common/ImageGallery/ImageGallery.tsx
+++ b/next/modules/common/ImageGallery/ImageGallery.tsx
@@ -77,10 +77,13 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
           tabIndex={0}
           aria-label={t('openImageGallery')}
           onKeyUp={onEnterOrSpaceKeyDown(() => openAtImageIndex(0))}
-          className={cx('outline-primary cursor-default outline-offset-2 focus:outline-4', {
-            'flex flex-col ': variant === 'below',
-            'grid grid-cols-[minmax(0,1fr)_auto]': variant === 'aside',
-          })}
+          className={cx(
+            'outline-primary cursor-default outline-none ring-offset-2 transition focus-visible:ring',
+            {
+              'flex flex-col ': variant === 'below',
+              'grid grid-cols-[minmax(0,1fr)_auto]': variant === 'aside',
+            }
+          )}
         >
           {/* first image */}
           {firstImage && (

--- a/next/modules/common/ImageGallery/ImageGallery.tsx
+++ b/next/modules/common/ImageGallery/ImageGallery.tsx
@@ -77,13 +77,10 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
           tabIndex={0}
           aria-label={t('openImageGallery')}
           onKeyUp={onEnterOrSpaceKeyDown(() => openAtImageIndex(0))}
-          className={cx(
-            'outline-primary cursor-default outline-none ring-offset-2 transition focus-visible:ring',
-            {
-              'flex flex-col ': variant === 'below',
-              'grid grid-cols-[minmax(0,1fr)_auto]': variant === 'aside',
-            }
-          )}
+          className={cx('outline-primary base-focus-ring cursor-default', {
+            'flex flex-col ': variant === 'below',
+            'grid grid-cols-[minmax(0,1fr)_auto]': variant === 'aside',
+          })}
         >
           {/* first image */}
           {firstImage && (

--- a/next/modules/common/MDatePicker/MDatePicker.tsx
+++ b/next/modules/common/MDatePicker/MDatePicker.tsx
@@ -14,7 +14,13 @@ registerLocale('sk', sk)
 const MDatePicker = (props: ComponentProps<typeof ReactDatePicker>) => {
   const { i18n } = useTranslation()
 
-  return <ReactDatePicker locale={i18n.language} {...props} />
+  return (
+    <ReactDatePicker
+      locale={i18n.language}
+      {...props}
+      className="outline-none ring-offset-2 transition focus-visible:ring"
+    />
+  )
 }
 
 export default MDatePicker

--- a/next/modules/common/MDatePicker/MDatePicker.tsx
+++ b/next/modules/common/MDatePicker/MDatePicker.tsx
@@ -14,13 +14,7 @@ registerLocale('sk', sk)
 const MDatePicker = (props: ComponentProps<typeof ReactDatePicker>) => {
   const { i18n } = useTranslation()
 
-  return (
-    <ReactDatePicker
-      locale={i18n.language}
-      {...props}
-      className="outline-none ring-offset-2 transition focus-visible:ring"
-    />
-  )
+  return <ReactDatePicker locale={i18n.language} {...props} className="base-focus-ring" />
 }
 
 export default MDatePicker

--- a/next/modules/common/MLink.tsx
+++ b/next/modules/common/MLink.tsx
@@ -37,7 +37,7 @@ const MLink = forwardRef<HTMLAnchorElement, LinkProps>(
     ref
   ) => {
     const styles = twMerge(
-      cx({
+      cx('outline-none ring-offset-2 transition focus-visible:ring', {
         'hover:underline': variant === 'basic',
         'underline underline-offset-1 hover:text-foreground-body': variant === 'breadcrumb',
         'underline underline-offset-1 hover:text-foreground-dark': variant === 'richtext',

--- a/next/modules/common/MLink.tsx
+++ b/next/modules/common/MLink.tsx
@@ -37,7 +37,7 @@ const MLink = forwardRef<HTMLAnchorElement, LinkProps>(
     ref
   ) => {
     const styles = twMerge(
-      cx('outline-none ring-offset-2 transition focus-visible:ring', {
+      cx('base-focus-ring', {
         'hover:underline': variant === 'basic',
         'underline underline-offset-1 hover:text-foreground-body': variant === 'breadcrumb',
         'underline underline-offset-1 hover:text-foreground-dark': variant === 'richtext',

--- a/next/modules/navigation/MobileLatestEvents.tsx
+++ b/next/modules/navigation/MobileLatestEvents.tsx
@@ -15,7 +15,8 @@ const MobileLatestEvents = () => {
     <ul className="mt-2 flex flex-col gap-y-3">
       {upcomingEvents.data.filter(isDefined).map((event, index) => {
         return (
-          <li key={event?.id ?? index}>
+          // eslint-disable-next-line react/no-array-index-key
+          <li key={index}>
             <EventRow event={event} />
           </li>
         )

--- a/next/modules/navigation/MobileLatestEvents.tsx
+++ b/next/modules/navigation/MobileLatestEvents.tsx
@@ -10,11 +10,15 @@ const MobileLatestEvents = () => {
   if (!upcomingEvents?.data.length) {
     return null
   }
-
+  
   return (
     <ul className="mt-2 flex flex-col gap-y-3">
-      {upcomingEvents.data.filter(isDefined).map((event) => {
-        return <EventRow event={event} />
+      {upcomingEvents.data.filter(isDefined).map((event, index) => {
+        return (
+          <li key={event?.id ?? index}>
+            <EventRow event={event} />
+          </li>
+        )
       })}
     </ul>
   )

--- a/next/modules/navigation/NavMenuLatestEvents.tsx
+++ b/next/modules/navigation/NavMenuLatestEvents.tsx
@@ -15,7 +15,8 @@ const NavMenuLatestEvents = () => {
     <ul className="mt-2 grid grid-flow-col grid-rows-2 gap-x-5 gap-y-3">
       {upcomingEvents.data.filter(isDefined).map((event, index) => {
         return (
-          <li key={event?.id ?? index}>
+          // eslint-disable-next-line react/no-array-index-key
+          <li key={index}>
             <NavigationMenu.Link asChild>
               <EventRow event={event} />
             </NavigationMenu.Link>

--- a/next/modules/navigation/NavMenuLatestEvents.tsx
+++ b/next/modules/navigation/NavMenuLatestEvents.tsx
@@ -13,11 +13,13 @@ const NavMenuLatestEvents = () => {
 
   return (
     <ul className="mt-2 grid grid-flow-col grid-rows-2 gap-x-5 gap-y-3">
-      {upcomingEvents.data.filter(isDefined).map((event) => {
+      {upcomingEvents.data.filter(isDefined).map((event, index) => {
         return (
-          <NavigationMenu.Link asChild key={event.id}>
-            <EventRow event={event} />
-          </NavigationMenu.Link>
+          <li key={event?.id ?? index}>
+            <NavigationMenu.Link asChild>
+              <EventRow event={event} />
+            </NavigationMenu.Link>
+          </li>
         )
       })}
     </ul>

--- a/next/modules/navigation/NavMenuTrigger.tsx
+++ b/next/modules/navigation/NavMenuTrigger.tsx
@@ -17,6 +17,7 @@ const NavMenuTrigger = forwardRef<HTMLButtonElement, NavMenuTriggerProps>(
         onPointerMove={(event) => event.preventDefault()}
         onPointerLeave={(event) => event.preventDefault()}
         className={cx(
+          // Using `ring-inset` because offset doesn't look appealing in this context
           'flex h-full w-full items-end pb-1 text-h5 outline-none ring-inset transition hover:underline focus-visible:ring data-[state=open]:underline',
           {
             'pl-3': !isFirst,

--- a/next/modules/navigation/NavMenuTrigger.tsx
+++ b/next/modules/navigation/NavMenuTrigger.tsx
@@ -17,7 +17,7 @@ const NavMenuTrigger = forwardRef<HTMLButtonElement, NavMenuTriggerProps>(
         onPointerMove={(event) => event.preventDefault()}
         onPointerLeave={(event) => event.preventDefault()}
         className={cx(
-          'flex h-full w-full items-end pb-1 text-h5 hover:underline data-[state=open]:underline',
+          'flex h-full w-full items-end pb-1 text-h5 outline-none ring-inset transition hover:underline focus-visible:ring data-[state=open]:underline',
           {
             'pl-3': !isFirst,
           }

--- a/next/modules/sections/PartnersSection.tsx
+++ b/next/modules/sections/PartnersSection.tsx
@@ -19,7 +19,8 @@ const PartnersSection = () => {
       {data?.featuredPartners && data.featuredPartners.data.length > 0 && (
         <ul className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-3">
           {data.featuredPartners.data.map((partner, index) => (
-            <li key={partner?.id ?? index}>
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={index}>
               <PartnerCardRow
                 id={`featured-partner-${index}`}
                 title={partner?.attributes?.title ?? ''}
@@ -35,7 +36,8 @@ const PartnersSection = () => {
       {data?.notFeaturedPartners && data.notFeaturedPartners.data.length > 0 && (
         <ul className="mt-12 flex flex-col lg:space-y-3">
           {data.notFeaturedPartners.data.map((partner, index) => (
-            <li key={partner?.id ?? index}>
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={index}>
               <PartnerCardRow
                 id={`non-featured-partner-${index}`}
                 title={partner?.attributes?.title || ''}

--- a/next/modules/sections/PartnersSection.tsx
+++ b/next/modules/sections/PartnersSection.tsx
@@ -19,15 +19,15 @@ const PartnersSection = () => {
       {data?.featuredPartners && data.featuredPartners.data.length > 0 && (
         <ul className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-3">
           {data.featuredPartners.data.map((partner, index) => (
-            <PartnerCardRow
-              // eslint-disable-next-line react/no-array-index-key
-              key={index}
-              id={`featured-partner-${index}`}
-              title={partner?.attributes?.title ?? ''}
-              logo={partner?.attributes?.logo?.data?.attributes?.url ?? ''}
-              linkHref={partner?.attributes?.url ?? '#'}
-              featured
-            />
+            <li key={partner?.id ?? index}>
+              <PartnerCardRow
+                id={`featured-partner-${index}`}
+                title={partner?.attributes?.title ?? ''}
+                logo={partner?.attributes?.logo?.data?.attributes?.url ?? ''}
+                linkHref={partner?.attributes?.url ?? '#'}
+                featured
+              />
+            </li>
           ))}
         </ul>
       )}
@@ -35,13 +35,13 @@ const PartnersSection = () => {
       {data?.notFeaturedPartners && data.notFeaturedPartners.data.length > 0 && (
         <ul className="mt-12 flex flex-col lg:space-y-3">
           {data.notFeaturedPartners.data.map((partner, index) => (
-            <PartnerCardRow
-              // eslint-disable-next-line react/no-array-index-key
-              key={index}
-              id={`non-featured-partner-${index}`}
-              title={partner?.attributes?.title || ''}
-              linkHref={partner?.attributes?.url || ''}
-            />
+            <li key={partner?.id ?? index}>
+              <PartnerCardRow
+                id={`non-featured-partner-${index}`}
+                title={partner?.attributes?.title || ''}
+                linkHref={partner?.attributes?.url || ''}
+              />
+            </li>
           ))}
         </ul>
       )}

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -48,7 +48,7 @@ body {
 @layer components {
   .base-input {
     @apply box-border inline-block appearance-none border bg-white px-3 py-2 text-base text-foreground-heading;
-    @apply border-border-light placeholder:text-foreground-body hover:border-border-dark focus:border-border-dark focus:outline-none;
+    @apply border-border-light placeholder:text-foreground-body hover:border-border-dark focus:border-border-dark;
   }
 
   .base-input--with-error {

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -59,6 +59,10 @@ body {
     @apply flex h-5 w-5 items-center rounded-full border-2 border-border-dark;
     @apply box-border justify-center overflow-hidden;
   }
+
+  .base-focus-ring {
+    @apply outline-none ring-offset-2 transition focus-visible:ring;
+  }
 }
 
 .chq-atc--button > svg {


### PR DESCRIPTION
### Description
- Refactor focus ring behaviour across the repository

### Supplementary notes
- In input-based elements, focus rings are displayed when the elements are being clicked
- As per the discussion in this [thread](https://github.com/WICG/focus-visible/issues/131), this is the anticipated behaviour. We have the option of either accepting the browser’s behaviour or choosing to remove focus rings from input-based elements
- **Trickier components not handled in this PR are: `PromoEventCard`, `DesktopBreadcrumbs`, `BranchDetails`, `TagButton` and search result cards in `SearchPage` - these elements appear to be slightly cropped by their parent components**

<img width="1295" alt="Screenshot 2025-01-22 at 12 22 34" src="https://github.com/user-attachments/assets/7841468a-5557-45b8-98a6-83536e099d2c" />
<img width="745" alt="Screenshot 2025-01-22 at 12 22 58" src="https://github.com/user-attachments/assets/b01fa356-8a81-4859-8539-d87e1eb831a2" />
<img width="1369" alt="Screenshot 2025-01-22 at 12 24 01" src="https://github.com/user-attachments/assets/53f53253-567d-4a06-8dbd-2316d0aaf6f6" />



#### Other potential improvements

* **StepNumberTitle** could be replaced by a button
* **NewsletterSection**: We inject HTML into this component. The link, which is part of the injected text, does not use our custom focus rings. It uses the default browser one

### Testing
- When navigating the page using only the keyboard (with the Tab key), all interactive elements that currently have tab focus should be accompanied by a focus ring

### Screenshots
<img width="1246" alt="Screenshot 2025-01-22 at 12 16 03" src="https://github.com/user-attachments/assets/5453b94f-371a-4102-9cc2-da8f24d5e892" />
<img width="1234" alt="Screenshot 2025-01-22 at 12 16 44" src="https://github.com/user-attachments/assets/6ec70901-a0ff-4028-bc49-b42a6b69acfa" />
<img width="958" alt="Screenshot 2025-01-22 at 12 17 30" src="https://github.com/user-attachments/assets/ff3531ce-266d-4370-a09f-3e241d66a892" />
<img width="947" alt="Screenshot 2025-01-22 at 12 18 34" src="https://github.com/user-attachments/assets/525a51b4-4f46-4fa5-ba18-f074b3189002" />
<img width="1266" alt="Screenshot 2025-01-22 at 12 19 27" src="https://github.com/user-attachments/assets/f3064035-08f4-4026-9984-7663e8cec87c" />
