### PR TITLE
#344 Show banner with current change of opening hours

### DIFF
--- a/next/components/Molecules/BranchDetails/ContactsAndOpeningHours.tsx
+++ b/next/components/Molecules/BranchDetails/ContactsAndOpeningHours.tsx
@@ -1,3 +1,4 @@
+import OpeningHoursChangeAlert from '@components/Molecules/OpeningHoursChangeAlert'
 import { BranchPlaceEntityFragment } from '@services/graphql'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -17,9 +18,10 @@ const ContactsAndOpeningHours = ({ branch, branches }: ContactsAndOpeningHoursPr
   }
 
   return (
-    <div className="pt-10" id="sections">
+    <div className="flex flex-col gap-5 pt-10" id="sections">
       <div className="text-[24px]">{t('sections')}</div>
-      <div className="pt-5">
+      <OpeningHoursChangeAlert />
+      <div>
         <BranchContactUsOpeningHoursInfo branch={branch} />
         {branches &&
           branches.map((subBranch) => <BranchContactUsOpeningHoursInfo branch={subBranch} />)}

--- a/next/components/Molecules/OpeningHoursChangeAlert.tsx
+++ b/next/components/Molecules/OpeningHoursChangeAlert.tsx
@@ -1,4 +1,4 @@
-import MLink from '@modules/common/MLink'
+import ShowMoreLink from '@modules/common/ShowMoreLink'
 import { client } from '@services/graphql/gql'
 import { isDefined } from '@utils/isDefined'
 import { useNavikronos } from '@utils/navikronos'
@@ -39,9 +39,7 @@ const OpeningHoursChangeAlert = () => {
                 {index > 0 && <hr />}
                 <div className="flex flex-col gap-3">
                   <p className="text-foreground-body">{title}</p>
-                  <MLink href={link ?? ''} variant="basic" hasIcon>
-                    {t('showMore')}
-                  </MLink>
+                  <ShowMoreLink href={link ?? '#'}>{t('showMore')}</ShowMoreLink>
                 </div>
               </Fragment>
             )

--- a/next/components/Molecules/OpeningHoursChangeAlert.tsx
+++ b/next/components/Molecules/OpeningHoursChangeAlert.tsx
@@ -3,12 +3,13 @@ import { client } from '@services/graphql/gql'
 import { isDefined } from '@utils/isDefined'
 import { useNavikronos } from '@utils/navikronos'
 import { useTranslation } from 'next-i18next'
-import React, { Fragment } from 'react'
+import React, { Fragment, useId } from 'react'
 import { useQuery } from 'react-query'
 
 const OpeningHoursChangeAlert = () => {
   const { t, i18n } = useTranslation()
   const locale = i18n.language
+  const alertBannerId = useId()
 
   const { getPathForStrapiEntity } = useNavikronos()
 
@@ -32,14 +33,19 @@ const OpeningHoursChangeAlert = () => {
 
             const { title } = notice.attributes
             const link = getPathForStrapiEntity(notice)
+            const id = `${alertBannerId}-${index}`
 
             return (
               // eslint-disable-next-line react/no-array-index-key
               <Fragment key={index}>
                 {index > 0 && <hr />}
                 <div className="flex flex-col gap-3">
-                  <p className="text-foreground-body">{title}</p>
-                  <ShowMoreLink href={link ?? '#'}>{t('showMore')}</ShowMoreLink>
+                  <p className="text-foreground-body" id={id}>
+                    {title}
+                  </p>
+                  <ShowMoreLink href={link ?? '#'} aria-labelledby={id}>
+                    {t('showMore')}
+                  </ShowMoreLink>
                 </div>
               </Fragment>
             )

--- a/next/components/Molecules/OpeningHoursChangeAlert.tsx
+++ b/next/components/Molecules/OpeningHoursChangeAlert.tsx
@@ -1,0 +1,56 @@
+import MLink from '@modules/common/MLink'
+import { client } from '@services/graphql/gql'
+import { isDefined } from '@utils/isDefined'
+import { useNavikronos } from '@utils/navikronos'
+import { useTranslation } from 'next-i18next'
+import React, { Fragment } from 'react'
+import { useQuery } from 'react-query'
+
+const OpeningHoursChangeAlert = () => {
+  const { t, i18n } = useTranslation()
+  const locale = i18n.language
+
+  const { getPathForStrapiEntity } = useNavikronos()
+
+  const { data: noticesData } = useQuery({
+    queryFn: () => client.OpeningHoursChangeNotices({ locale }),
+    queryKey: ['OpeningHoursChangeBlogPosts', locale],
+  })
+
+  // eslint-disable-next-line unicorn/no-array-callback-reference
+  const filteredNotices = noticesData?.notices?.data.filter(isDefined) ?? []
+
+  if (filteredNotices.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-5 bg-promo-peach p-5">
+      <h2 className="text-h5">{t('openingHoursChangeAlertTitle')}</h2>
+      <div className="flex flex-col gap-6">
+        {filteredNotices
+          ?.map((notice, index) => {
+            if (!notice.attributes) return null
+
+            const { title } = notice.attributes
+            const link = getPathForStrapiEntity(notice)
+
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Fragment key={index}>
+                {index > 0 && <hr />}
+                <div className="flex flex-col gap-3">
+                  <p className="text-foreground-body">{title}</p>
+                  <MLink href={link ?? ''} variant="basic" hasIcon>
+                    {t('showMore')}
+                  </MLink>
+                </div>
+              </Fragment>
+            )
+          })
+          // eslint-disable-next-line unicorn/no-array-callback-reference
+          .filter(isDefined)}
+      </div>
+    </div>
+  )
+}
+
+export default OpeningHoursChangeAlert

--- a/next/components/Molecules/OpeningHoursChangeAlert.tsx
+++ b/next/components/Molecules/OpeningHoursChangeAlert.tsx
@@ -15,7 +15,7 @@ const OpeningHoursChangeAlert = () => {
 
   const { data: noticesData } = useQuery({
     queryFn: () => client.OpeningHoursChangeNotices({ locale }),
-    queryKey: ['OpeningHoursChangeBlogPosts', locale],
+    queryKey: ['OpeningHoursChangeNotices', locale],
   })
 
   // eslint-disable-next-line unicorn/no-array-callback-reference

--- a/next/modules/sections/OpeningHoursSection.tsx
+++ b/next/modules/sections/OpeningHoursSection.tsx
@@ -1,22 +1,31 @@
 import BranchOpeningHours from '@components/Molecules/BranchDetails/ContactUsOpeningHours/BranchOpeningHours'
+import OpeningHoursChangeAlert from '@components/Molecules/OpeningHoursChangeAlert'
 import { OpeningHoursSectionFragment } from '@services/graphql'
 import { isDefined } from '@utils/isDefined'
 import React from 'react'
 
 const OpeningHoursSection = ({ title, branchList }: Omit<OpeningHoursSectionFragment, 'id'>) => {
+  const filteredBranches = branchList?.data.filter(isDefined) ?? []
+
   return (
-    <div className="">
+    <div className="flex flex-col gap-8">
       {title && <h2 className="text-h3">{title}</h2>}
-      {branchList?.data.filter(isDefined).map((branch) => {
-        return (
-          <div className="border-t border-border-dark py-6 first:pt-0 first-of-type:border-none lg:py-8">
-            <h3 className="text-h4">{branch.attributes?.title}</h3>
-            <div className="mt-4">
-              <BranchOpeningHours days={branch.attributes?.openingHours?.days ?? []} />
-            </div>
-          </div>
-        )
-      })}
+      <OpeningHoursChangeAlert />
+      {filteredBranches.length > 0 ? (
+        <div className="flex flex-col gap-6 lg:gap-8">
+          {filteredBranches.map((branch, index) => {
+            return (
+              <>
+                {index > 0 && <div className="border-t border-border-dark" aria-hidden />}
+                <div className="flex flex-col gap-4">
+                  <h3 className="text-h4">{branch.attributes?.title}</h3>
+                  <BranchOpeningHours days={branch.attributes?.openingHours?.days ?? []} />
+                </div>
+              </>
+            )
+          })}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -12,6 +12,7 @@
   "openingHours": "Opening hours",
   "openingHoursOpenUntil": "Open until",
   "openingHoursClosed": "Currently closed",
+  "openingHoursChangeAlertTitle": "Notice, change of opening hours!",
   "copyright": "Bratislava City Library",
   "category": "Category",
   "coverImageFor": "Cover image for {{title}}",

--- a/next/public/locales/sk/common.json
+++ b/next/public/locales/sk/common.json
@@ -12,6 +12,7 @@
   "openingHours": "Otváracie hodiny",
   "openingHoursOpenUntil": "Dnes je otvorené do",
   "openingHoursClosed": "Teraz je zatvorené",
+  "openingHoursChangeAlertTitle": "Pozor, zmena otváracích hodín!",
   "copyright": "Mestská knižnica v Bratislave",
   "category": "Kategórie",
   "coverImageFor": "Ilustračný obrázok pre {{title}}",

--- a/next/services/graphql/index.ts
+++ b/next/services/graphql/index.ts
@@ -113,7 +113,6 @@ export type BlogPost = {
   __typename?: 'BlogPost'
   coverMedia?: Maybe<UploadFileEntityResponse>
   createdAt?: Maybe<Scalars['DateTime']>
-  isCurrentChangeInOpeningHours?: Maybe<Scalars['Boolean']>
   locale?: Maybe<Scalars['String']>
   localizations?: Maybe<BlogPostRelationResponseCollection>
   publishedAt?: Maybe<Scalars['DateTime']>
@@ -152,7 +151,6 @@ export type BlogPostFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<BlogPostFiltersInput>>>
   createdAt?: InputMaybe<DateTimeFilterInput>
   id?: InputMaybe<IdFilterInput>
-  isCurrentChangeInOpeningHours?: InputMaybe<BooleanFilterInput>
   locale?: InputMaybe<StringFilterInput>
   localizations?: InputMaybe<BlogPostFiltersInput>
   not?: InputMaybe<BlogPostFiltersInput>
@@ -166,7 +164,6 @@ export type BlogPostFiltersInput = {
 
 export type BlogPostInput = {
   coverMedia?: InputMaybe<Scalars['ID']>
-  isCurrentChangeInOpeningHours?: InputMaybe<Scalars['Boolean']>
   publishedAt?: InputMaybe<Scalars['DateTime']>
   sections?: InputMaybe<Array<Scalars['BlogPostSectionsDynamicZoneInput']>>
   seo?: InputMaybe<ComponentCommonSeoInput>
@@ -3581,6 +3578,7 @@ export type Notice = {
   createdAt?: Maybe<Scalars['DateTime']>
   dateAdded?: Maybe<Scalars['Date']>
   documents?: Maybe<ComponentSectionsDocuments>
+  isCurrentChangeInOpeningHours?: Maybe<Scalars['Boolean']>
   listingImage?: Maybe<UploadFileEntityResponse>
   locale?: Maybe<Scalars['String']>
   localizations?: Maybe<NoticeRelationResponseCollection>
@@ -3623,6 +3621,7 @@ export type NoticeFiltersInput = {
   dateAdded?: InputMaybe<DateFilterInput>
   documents?: InputMaybe<ComponentSectionsDocumentsFiltersInput>
   id?: InputMaybe<IdFilterInput>
+  isCurrentChangeInOpeningHours?: InputMaybe<BooleanFilterInput>
   locale?: InputMaybe<StringFilterInput>
   localizations?: InputMaybe<NoticeFiltersInput>
   not?: InputMaybe<NoticeFiltersInput>
@@ -3639,6 +3638,7 @@ export type NoticeInput = {
   body?: InputMaybe<Scalars['String']>
   dateAdded?: InputMaybe<Scalars['Date']>
   documents?: InputMaybe<ComponentSectionsDocumentsInput>
+  isCurrentChangeInOpeningHours?: InputMaybe<Scalars['Boolean']>
   listingImage?: InputMaybe<Scalars['ID']>
   promoted?: InputMaybe<Scalars['Boolean']>
   publishedAt?: InputMaybe<Scalars['DateTime']>

--- a/next/services/graphql/index.ts
+++ b/next/services/graphql/index.ts
@@ -12528,7 +12528,7 @@ export const OpeningHoursChangeNoticesDocument = gql`
   query OpeningHoursChangeNotices($locale: I18NLocaleCode!) {
     notices(
       filters: { isCurrentChangeInOpeningHours: { eq: true } }
-      sort: "addedAt:desc"
+      sort: "publishedAt:desc"
       pagination: { limit: -1 }
       locale: $locale
     ) {

--- a/next/services/graphql/index.ts
+++ b/next/services/graphql/index.ts
@@ -8813,6 +8813,27 @@ export type NoticeBySlugQuery = {
   } | null
 }
 
+export type OpeningHoursChangeNoticesQueryVariables = Exact<{
+  locale: Scalars['I18NLocaleCode']
+}>
+
+export type OpeningHoursChangeNoticesQuery = {
+  __typename?: 'Query'
+  notices?: {
+    __typename?: 'NoticeEntityResponseCollection'
+    data: Array<{
+      __typename: 'NoticeEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Notice'
+        slug: string
+        locale?: string | null
+        title: string
+      } | null
+    }>
+  } | null
+}
+
 type PageSections_ComponentSectionsAccordion_Fragment = {
   __typename: 'ComponentSectionsAccordion'
   id: string
@@ -12503,6 +12524,26 @@ export const NoticeBySlugDocument = gql`
   }
   ${NoticeEntityFragmentDoc}
 `
+export const OpeningHoursChangeNoticesDocument = gql`
+  query OpeningHoursChangeNotices($locale: I18NLocaleCode!) {
+    notices(
+      filters: { isCurrentChangeInOpeningHours: { eq: true } }
+      sort: "addedAt:desc"
+      pagination: { limit: -1 }
+      locale: $locale
+    ) {
+      data {
+        __typename
+        id
+        attributes {
+          slug
+          locale
+          title
+        }
+      }
+    }
+  }
+`
 export const PagesStaticPathsDocument = gql`
   query PagesStaticPaths($locale: I18NLocaleCode) {
     pages(locale: $locale) {
@@ -12824,6 +12865,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'NoticeBySlug',
+        'query'
+      )
+    },
+    OpeningHoursChangeNotices(
+      variables: OpeningHoursChangeNoticesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<OpeningHoursChangeNoticesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<OpeningHoursChangeNoticesQuery>(
+            OpeningHoursChangeNoticesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'OpeningHoursChangeNotices',
         'query'
       )
     },

--- a/next/services/graphql/queries/Notices.graphql
+++ b/next/services/graphql/queries/Notices.graphql
@@ -98,7 +98,7 @@ query NoticeBySlug($slug: String!, $locale: I18NLocaleCode!) {
 query OpeningHoursChangeNotices($locale: I18NLocaleCode!) {
   notices(
     filters: { isCurrentChangeInOpeningHours: { eq: true } }
-    sort: "addedAt:desc"
+    sort: "publishedAt:desc"
     pagination: { limit: -1 }
     locale: $locale
   ) {

--- a/next/services/graphql/queries/Notices.graphql
+++ b/next/services/graphql/queries/Notices.graphql
@@ -74,11 +74,7 @@ query NoticesStaticPaths($locale: I18NLocaleCode!) {
   }
 }
 
-query Notices(
-  $locale: I18NLocaleCode!
-  $limit: Int
-  $start: Int
-) {
+query Notices($locale: I18NLocaleCode!, $limit: Int, $start: Int) {
   notices(locale: $locale, pagination: { limit: $limit, start: $start }, sort: "publishedAt:desc") {
     data {
       ...NoticeListingEntity
@@ -95,6 +91,25 @@ query NoticeBySlug($slug: String!, $locale: I18NLocaleCode!) {
   notices(locale: $locale, filters: { slug: { eq: $slug } }) {
     data {
       ...NoticeEntity
+    }
+  }
+}
+
+query OpeningHoursChangeNotices($locale: I18NLocaleCode!) {
+  notices(
+    filters: { isCurrentChangeInOpeningHours: { eq: true } }
+    sort: "addedAt:desc"
+    pagination: { limit: -1 }
+    locale: $locale
+  ) {
+    data {
+      __typename
+      id
+      attributes {
+        slug
+        locale
+        title
+      }
     }
   }
 }

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -72,7 +72,6 @@ type BasicDocumentRelationResponseCollection {
 type BlogPost {
   coverMedia: UploadFileEntityResponse
   createdAt: DateTime
-  isCurrentChangeInOpeningHours: Boolean
   locale: String
   localizations(filters: BlogPostFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): BlogPostRelationResponseCollection
   publishedAt: DateTime
@@ -101,7 +100,6 @@ input BlogPostFiltersInput {
   and: [BlogPostFiltersInput]
   createdAt: DateTimeFilterInput
   id: IDFilterInput
-  isCurrentChangeInOpeningHours: BooleanFilterInput
   locale: StringFilterInput
   localizations: BlogPostFiltersInput
   not: BlogPostFiltersInput
@@ -115,7 +113,6 @@ input BlogPostFiltersInput {
 
 input BlogPostInput {
   coverMedia: ID
-  isCurrentChangeInOpeningHours: Boolean
   publishedAt: DateTime
   sections: [BlogPostSectionsDynamicZoneInput!]
   seo: ComponentCommonSeoInput
@@ -2642,6 +2639,7 @@ type Notice {
   createdAt: DateTime
   dateAdded: Date
   documents: ComponentSectionsDocuments
+  isCurrentChangeInOpeningHours: Boolean
   listingImage: UploadFileEntityResponse
   locale: String
   localizations(filters: NoticeFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): NoticeRelationResponseCollection
@@ -2674,6 +2672,7 @@ input NoticeFiltersInput {
   dateAdded: DateFilterInput
   documents: ComponentSectionsDocumentsFiltersInput
   id: IDFilterInput
+  isCurrentChangeInOpeningHours: BooleanFilterInput
   locale: StringFilterInput
   localizations: NoticeFiltersInput
   not: NoticeFiltersInput
@@ -2690,6 +2689,7 @@ input NoticeInput {
   body: String
   dateAdded: Date
   documents: ComponentSectionsDocumentsInput
+  isCurrentChangeInOpeningHours: Boolean
   listingImage: ID
   promoted: Boolean
   publishedAt: DateTime

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -80,15 +80,6 @@
         }
       },
       "component": "common.seo"
-    },
-    "isCurrentChangeInOpeningHours": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": false
-        }
-      },
-      "type": "boolean",
-      "default": false
     }
   }
 }

--- a/strapi/src/api/notice/content-types/notice/schema.json
+++ b/strapi/src/api/notice/content-types/notice/schema.json
@@ -91,6 +91,15 @@
         }
       },
       "component": "common.seo"
+    },
+    "isCurrentChangeInOpeningHours": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
### What's done

- add banner that shows links to current notices about opening hours - same as in OLO

Notes:
- some styling was change so it was possible to insert the banner easily (changes to `flex-col` and gaps)
- field name and heptext in strapi needs to be edited in staging and prod strapi (we have no config-sync plugin in this project)
- before in #358, I accidentally added `isCurrentChangeInOpeningHours` flag into BlogPosts, but it needs to be in Notices content type

### Testing

- mark some notices as `isCurrentChangeInOpeningHours` (try none, one, and multiple)
- check if you see a banner:
  - on top of each sections on page `/navstivte/ostatne/otvaracie-hodiny`
  - in every branch detail page in "Contacts and opening hours section"

### Screenshots

![image](https://github.com/user-attachments/assets/b7bf21ea-84f9-4de6-bd7c-fcfd326efb23)

![image](https://github.com/user-attachments/assets/8ef015a3-32b0-4bbe-aa53-9f2e2ad059ee)

![image](https://github.com/user-attachments/assets/7b75257d-5c46-4502-befe-4c04c22981d6)
