### PR TITLE
#308 Fix focus ring issues - "cropped focus rings"

### DIFF
--- a/next/components/HomePage/SectionHomepageNewBooks.tsx
+++ b/next/components/HomePage/SectionHomepageNewBooks.tsx
@@ -18,7 +18,7 @@ const SectionHomepageNewBooks = ({ books }: SectionHomepageNewBooksProps) => {
       <section className="relative flex w-full flex-col py-10">
         <h2 className="text-center text-h3 md:text-left">{t('newBooksTitle')}</h2>
 
-        <div className="overflow-x-auto">
+        <div className="-mx-2 overflow-x-auto px-2">
           <div className="flex gap-x-4 py-6 xl:grid xl:grid-cols-6">
             {books.map((book) => (
               <div key={book.url} className="shrink-0">

--- a/next/components/HomePage/SectionLibraryNews.tsx
+++ b/next/components/HomePage/SectionLibraryNews.tsx
@@ -23,7 +23,7 @@ const SectionLibraryNews = ({ notices, newsSection }: LibraryNewsProps) => {
         <h2 className="text-center text-h3 md:text-left">{newsSection.title}</h2>
         <div className="w-full px-4 lg:px-0">
           <Carousel
-            listClassName="py-10 gap-4 lg:gap-8"
+            listClassName="py-10 gap-4 lg:gap-6 px-2 -mx-2 lg:pr-2"
             itemClassName="w-10/12 max-w-[268px] md:max-w-[271px]"
             items={notices.map((notice) => ({
               element: <NoticeCard notice={notice} />,

--- a/next/components/HomePage/SectionLibraryNews.tsx
+++ b/next/components/HomePage/SectionLibraryNews.tsx
@@ -23,7 +23,7 @@ const SectionLibraryNews = ({ notices, newsSection }: LibraryNewsProps) => {
         <h2 className="text-center text-h3 md:text-left">{newsSection.title}</h2>
         <div className="w-full px-4 lg:px-0">
           <Carousel
-            listClassName="py-10 gap-4 lg:gap-6 px-2 -mx-2 lg:pr-2"
+            listClassName="py-10 gap-4 lg:gap-8"
             itemClassName="w-10/12 max-w-[268px] md:max-w-[271px]"
             items={notices.map((notice) => ({
               element: <NoticeCard notice={notice} />,

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -13,31 +13,33 @@ interface SectionPromosProps {
 
 const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
-    <Carousel
-      listClassName="my-10 gap-4 px-4 lg:gap-5 h-full"
-      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
-      shiftIndex={3}
-      items={promos
-        ?.map((promo) => {
-          switch (promo.__typename) {
-            case 'EventEntity':
-              return {
-                element: <PromoEventCard event={withAttributes(promo)} />,
-                key: promo?.attributes?.slug,
-              }
+    <div className="-my-2 lg:-mx-2">
+      <Carousel
+        listClassName="my-10 gap-4 px-4 lg:px-2 lg:gap-5 h-full py-2"
+        itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
+        shiftIndex={3}
+        items={promos
+          ?.map((promo) => {
+            switch (promo.__typename) {
+              case 'EventEntity':
+                return {
+                  element: <PromoEventCard event={withAttributes(promo)} />,
+                  key: promo?.attributes?.slug,
+                }
 
-            case 'NoticeEntity':
-              return {
-                element: <PromoNewsCard notice={promo} />,
-                key: promo?.attributes?.slug,
-              }
+              case 'NoticeEntity':
+                return {
+                  element: <PromoNewsCard notice={promo} />,
+                  key: promo?.attributes?.slug,
+                }
 
-            default:
-              return { element: null, key: undefined }
-          }
-        })
-        .filter(isDefined)}
-    />
+              default:
+                return { element: null, key: undefined }
+            }
+          })
+          .filter(isDefined)}
+      />
+    </div>
   )
 }
 

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -15,7 +15,7 @@ const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
     <Carousel
       // heights include padding that is used together with negative margin to make the whole focus rings visible
-      listClassName="my-10 h-[366px] gap-4 md:h-[506px] py-2 -my-2 lg:gap-5 px-4 lg:px-0 lg:mx-0"
+      listClassName="my-10 h-[366px] gap-4 md:h-[506px] py-2 -my-2 lg:gap-5 px-4 lg:px-2 lg:-mx-2"
       itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
       className="my-10"
       shiftIndex={3}

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -13,33 +13,31 @@ interface SectionPromosProps {
 
 const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
-    <div className="-my-2 lg:-mx-2">
-      <Carousel
-        listClassName="my-10 gap-4 px-4 lg:px-2 lg:gap-5 h-full py-2"
-        itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
-        shiftIndex={3}
-        items={promos
-          ?.map((promo) => {
-            switch (promo.__typename) {
-              case 'EventEntity':
-                return {
-                  element: <PromoEventCard event={withAttributes(promo)} />,
-                  key: promo?.attributes?.slug,
-                }
+    <Carousel
+      listClassName="my-10 gap-4 px-4 lg:gap-5 h-full"
+      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
+      shiftIndex={3}
+      items={promos
+        ?.map((promo) => {
+          switch (promo.__typename) {
+            case 'EventEntity':
+              return {
+                element: <PromoEventCard event={withAttributes(promo)} />,
+                key: promo?.attributes?.slug,
+              }
 
-              case 'NoticeEntity':
-                return {
-                  element: <PromoNewsCard notice={promo} />,
-                  key: promo?.attributes?.slug,
-                }
+            case 'NoticeEntity':
+              return {
+                element: <PromoNewsCard notice={promo} />,
+                key: promo?.attributes?.slug,
+              }
 
-              default:
-                return { element: null, key: undefined }
-            }
-          })
-          .filter(isDefined)}
-      />
-    </div>
+            default:
+              return { element: null, key: undefined }
+          }
+        })
+        .filter(isDefined)}
+    />
   )
 }
 

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -13,33 +13,32 @@ interface SectionPromosProps {
 
 const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
-    <div className="-my-2 lg:-mx-2">
-      <Carousel
-        listClassName="my-10 gap-4 px-4 lg:px-2 lg:gap-5 h-full py-2"
-        itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
-        shiftIndex={3}
-        items={promos
-          ?.map((promo) => {
-            switch (promo.__typename) {
-              case 'EventEntity':
-                return {
-                  element: <PromoEventCard event={withAttributes(promo)} />,
-                  key: promo?.attributes?.slug,
-                }
+    <Carousel
+      listClassName="gap-4 px-4 lg:-mx-2 lg:px-2 h-full lg:gap-5 py-2 -my-2"
+      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
+      className="my-10"
+      shiftIndex={3}
+      items={promos
+        ?.map((promo) => {
+          switch (promo.__typename) {
+            case 'EventEntity':
+              return {
+                element: <PromoEventCard event={withAttributes(promo)} />,
+                key: promo?.attributes?.slug,
+              }
 
-              case 'NoticeEntity':
-                return {
-                  element: <PromoNewsCard notice={promo} />,
-                  key: promo?.attributes?.slug,
-                }
+            case 'NoticeEntity':
+              return {
+                element: <PromoNewsCard notice={promo} />,
+                key: promo?.attributes?.slug,
+              }
 
-              default:
-                return { element: null, key: undefined }
-            }
-          })
-          .filter(isDefined)}
-      />
-    </div>
+            default:
+              return { element: null, key: undefined }
+          }
+        })
+        .filter(isDefined)}
+    />
   )
 }
 

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -13,31 +13,33 @@ interface SectionPromosProps {
 
 const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
-    <Carousel
-      listClassName="my-10 h-[350px] gap-4 px-4 lg:px-0 md:h-[490px] lg:gap-5"
-      itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
-      shiftIndex={3}
-      items={promos
-        ?.map((promo) => {
-          switch (promo.__typename) {
-            case 'EventEntity':
-              return {
-                element: <PromoEventCard event={withAttributes(promo)} />,
-                key: promo?.attributes?.slug,
-              }
+    <div className="-my-2 lg:-mx-2">
+      <Carousel
+        listClassName="my-10 gap-4 px-4 lg:px-2 lg:gap-5 h-full py-2"
+        itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
+        shiftIndex={3}
+        items={promos
+          ?.map((promo) => {
+            switch (promo.__typename) {
+              case 'EventEntity':
+                return {
+                  element: <PromoEventCard event={withAttributes(promo)} />,
+                  key: promo?.attributes?.slug,
+                }
 
-            case 'NoticeEntity':
-              return {
-                element: <PromoNewsCard notice={promo} />,
-                key: promo?.attributes?.slug,
-              }
+              case 'NoticeEntity':
+                return {
+                  element: <PromoNewsCard notice={promo} />,
+                  key: promo?.attributes?.slug,
+                }
 
-            default:
-              return { element: null, key: undefined }
-          }
-        })
-        .filter(isDefined)}
-    />
+              default:
+                return { element: null, key: undefined }
+            }
+          })
+          .filter(isDefined)}
+      />
+    </div>
   )
 }
 

--- a/next/components/HomePage/SectionPromos.tsx
+++ b/next/components/HomePage/SectionPromos.tsx
@@ -14,7 +14,8 @@ interface SectionPromosProps {
 const SectionPromos = ({ promos }: SectionPromosProps) => {
   return (
     <Carousel
-      listClassName="gap-4 px-4 lg:-mx-2 lg:px-2 h-full lg:gap-5 py-2 -my-2"
+      // heights include padding that is used together with negative margin to make the whole focus rings visible
+      listClassName="my-10 h-[366px] gap-4 md:h-[506px] py-2 -my-2 lg:gap-5 px-4 lg:px-0 lg:mx-0"
       itemClassName="w-10/12 max-w-[268px] md:max-w-[379px]"
       className="my-10"
       shiftIndex={3}

--- a/next/components/Molecules/BranchDetails/BranchDetails.tsx
+++ b/next/components/Molecules/BranchDetails/BranchDetails.tsx
@@ -37,11 +37,11 @@ const BranchDetails = ({ branch }: PageProps) => {
         <div>
           <div className="border-b border-border-dark pb-10">
             <div className="py-[12px] text-[32px]">
-              <div className="pb-8">
+              <div className="pb-6">
                 <h1 className="text-h1">{title}</h1>
 
-                <div className="-mx-4 -mb-2 overflow-x-auto">
-                  <div className="flex gap-x-6 px-4 pb-2 pt-9 text-sm uppercase">
+                <div className="-mx-4 -mb-2 overflow-x-auto pb-2">
+                  <div className="flex gap-x-6 px-4 pt-9 text-sm uppercase">
                     {AnchorLink('#description', t('description'))}
                     {servicePages?.data.length ? AnchorLink('#services', t('services')) : null}
                     {subBranches?.data.length ? AnchorLink('#sections', t('sections')) : null}

--- a/next/components/Molecules/BranchDetails/BranchDetails.tsx
+++ b/next/components/Molecules/BranchDetails/BranchDetails.tsx
@@ -40,7 +40,7 @@ const BranchDetails = ({ branch }: PageProps) => {
               <div className="pb-8">
                 <h1 className="text-h1">{title}</h1>
 
-                <div className="-mx-4 -mb-2 overflow-x-auto">
+                <div className="-mx-4 overflow-x-auto">
                   <div className="flex gap-x-6 px-4 pb-2 pt-9 text-sm uppercase">
                     {AnchorLink('#description', t('description'))}
                     {servicePages?.data.length ? AnchorLink('#services', t('services')) : null}

--- a/next/components/Molecules/BranchDetails/BranchDetails.tsx
+++ b/next/components/Molecules/BranchDetails/BranchDetails.tsx
@@ -40,8 +40,8 @@ const BranchDetails = ({ branch }: PageProps) => {
               <div className="pb-8">
                 <h1 className="text-h1">{title}</h1>
 
-                <div className="-mx-4 overflow-x-auto">
-                  <div className="flex gap-x-6 px-4 pt-9 text-sm uppercase focus:ring-2 focus:ring-outline">
+                <div className="-mx-4 -mb-2 overflow-x-auto">
+                  <div className="flex gap-x-6 px-4 pb-2 pt-9 text-sm uppercase">
                     {AnchorLink('#description', t('description'))}
                     {servicePages?.data.length ? AnchorLink('#services', t('services')) : null}
                     {subBranches?.data.length ? AnchorLink('#sections', t('sections')) : null}

--- a/next/components/Molecules/BranchDetails/BranchDetails.tsx
+++ b/next/components/Molecules/BranchDetails/BranchDetails.tsx
@@ -40,7 +40,7 @@ const BranchDetails = ({ branch }: PageProps) => {
               <div className="pb-8">
                 <h1 className="text-h1">{title}</h1>
 
-                <div className="-mx-4 overflow-x-auto">
+                <div className="-mx-4 -mb-2 overflow-x-auto">
                   <div className="flex gap-x-6 px-4 pb-2 pt-9 text-sm uppercase">
                     {AnchorLink('#description', t('description'))}
                     {servicePages?.data.length ? AnchorLink('#services', t('services')) : null}

--- a/next/components/pages/SearchPage.tsx
+++ b/next/components/pages/SearchPage.tsx
@@ -113,8 +113,8 @@ const SearchPage = () => {
             setSearchValue={setSearchValue}
           />
         </div>
-        <div className="mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
-          <ul className="-m-2 flex w-full items-center gap-3 overflow-auto p-2">
+        <div className="-m-2 mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
+          <ul className="flex w-full items-center gap-3 overflow-auto p-2">
             <li>
               <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
                 {t('allResults')}
@@ -138,8 +138,8 @@ const SearchPage = () => {
         </div>
 
         {/* eslint-disable-next-line sonarjs/no-redundant-boolean */}
-        <div className="mt-12 flex flex-col gap-6">
-          <AnimateHeight isVisible className="-m-2 p-2">
+        <div className="-m-2 mt-12 flex flex-col gap-6">
+          <AnimateHeight isVisible>
             {isLoading ? (
               <>
                 {Array.from({ length: filters.pageSize }, (_, index) => (
@@ -160,7 +160,7 @@ const SearchPage = () => {
                 {t('resultsFound', { count: 0 })}
               </motion.div>
             ) : (
-              <ul ref={resultsRef} className="flex flex-col">
+              <ul ref={resultsRef} className="flex flex-col p-2">
                 {data?.hits.map(({ title, type, id, slug }, index) => {
                   const link = getPathForEntity(
                     type === 'page' ? { type, id: String(id) } : { type, slug }

--- a/next/components/pages/SearchPage.tsx
+++ b/next/components/pages/SearchPage.tsx
@@ -160,7 +160,7 @@ const SearchPage = () => {
                 {t('resultsFound', { count: 0 })}
               </motion.div>
             ) : (
-              <ul ref={resultsRef} className="flex flex-col">
+              <ul ref={resultsRef} className="-mb-3 flex flex-col pb-3">
                 {data?.hits.map(({ title, type, id, slug }, index) => {
                   const link = getPathForEntity(
                     type === 'page' ? { type, id: String(id) } : { type, slug }

--- a/next/components/pages/SearchPage.tsx
+++ b/next/components/pages/SearchPage.tsx
@@ -113,8 +113,8 @@ const SearchPage = () => {
             setSearchValue={setSearchValue}
           />
         </div>
-        <div className="mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
-          <ul className="flex w-full items-center gap-3 overflow-auto pb-3 sm:pb-0">
+        <div className="-m-2 mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
+          <ul className="flex w-full items-center gap-3 overflow-auto p-2">
             <li>
               <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
                 {t('allResults')}
@@ -138,7 +138,7 @@ const SearchPage = () => {
         </div>
 
         {/* eslint-disable-next-line sonarjs/no-redundant-boolean */}
-        <div className="mt-12 flex flex-col gap-6">
+        <div className="-m-2 mt-12 flex flex-col gap-6">
           <AnimateHeight isVisible>
             {isLoading ? (
               <>
@@ -160,7 +160,7 @@ const SearchPage = () => {
                 {t('resultsFound', { count: 0 })}
               </motion.div>
             ) : (
-              <ul ref={resultsRef} className="flex flex-col">
+              <ul ref={resultsRef} className="flex flex-col p-2">
                 {data?.hits.map(({ title, type, id, slug }, index) => {
                   const link = getPathForEntity(
                     type === 'page' ? { type, id: String(id) } : { type, slug }

--- a/next/components/pages/SearchPage.tsx
+++ b/next/components/pages/SearchPage.tsx
@@ -113,8 +113,8 @@ const SearchPage = () => {
             setSearchValue={setSearchValue}
           />
         </div>
-        <div className="-m-2 mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
-          <ul className="flex w-full items-center gap-3 overflow-auto p-2">
+        <div className="mt-5 flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
+          <ul className="-m-2 flex w-full items-center gap-3 overflow-auto p-2">
             <li>
               <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
                 {t('allResults')}
@@ -138,8 +138,8 @@ const SearchPage = () => {
         </div>
 
         {/* eslint-disable-next-line sonarjs/no-redundant-boolean */}
-        <div className="-m-2 mt-12 flex flex-col gap-6">
-          <AnimateHeight isVisible>
+        <div className="mt-12 flex flex-col gap-6">
+          <AnimateHeight isVisible className="-m-2 p-2">
             {isLoading ? (
               <>
                 {Array.from({ length: filters.pageSize }, (_, index) => (
@@ -160,7 +160,7 @@ const SearchPage = () => {
                 {t('resultsFound', { count: 0 })}
               </motion.div>
             ) : (
-              <ul ref={resultsRef} className="flex flex-col p-2">
+              <ul ref={resultsRef} className="flex flex-col">
                 {data?.hits.map(({ title, type, id, slug }, index) => {
                   const link = getPathForEntity(
                     type === 'page' ? { type, id: String(id) } : { type, slug }

--- a/next/components/ui/MapSection/MapSection.tsx
+++ b/next/components/ui/MapSection/MapSection.tsx
@@ -143,7 +143,7 @@ const MapSection = ({ branches, mapboxAccessToken, title, altDesign = false }: M
             return (
               <CardWrapper
                 key={branch.id}
-                className={cx('relative', {
+                className={cx('relative ring-inset', {
                   'lg:border-l-0': index === 0 && !altDesign,
                   'w-70 flex-shrink-0 border border-border-dark lg:mb-6 lg:w-auto lg:flex-1 lg:border-r-0 lg:border-t-0 lg:border-b-0 lg:focus-within:border-transparent':
                     !altDesign,

--- a/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -9,8 +9,8 @@ const DesktopBreadcrumbs = ({ crumbs, ...rest }: BreadcrumbsProps) => {
   const { navProps } = useBreadcrumbs(rest)
 
   return (
-    <nav {...navProps} className="-mx-2 flex min-w-0 text-sm">
-      <ol className="flex w-fit items-center overflow-hidden py-4 px-2">
+    <nav {...navProps} className="flex min-w-0 text-sm">
+      <ol className="-mx-2 flex w-fit items-center overflow-hidden py-4 px-2">
         <BreadcrumbItem url="/">
           <HomeIcon />
           <span className="sr-only">{t('homepage')}</span>

--- a/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -9,8 +9,8 @@ const DesktopBreadcrumbs = ({ crumbs, ...rest }: BreadcrumbsProps) => {
   const { navProps } = useBreadcrumbs(rest)
 
   return (
-    <nav {...navProps} className="flex min-w-0 text-sm">
-      <ol className="flex w-fit items-center overflow-hidden py-4">
+    <nav {...navProps} className="-mx-2 flex min-w-0 text-sm">
+      <ol className="flex w-fit items-center overflow-hidden py-4 px-2">
         <BreadcrumbItem url="/">
           <HomeIcon />
           <span className="sr-only">{t('homepage')}</span>

--- a/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/next/modules/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -9,8 +9,8 @@ const DesktopBreadcrumbs = ({ crumbs, ...rest }: BreadcrumbsProps) => {
   const { navProps } = useBreadcrumbs(rest)
 
   return (
-    <nav {...navProps} className="flex min-w-0 text-sm">
-      <ol className="-mx-2 flex w-fit items-center overflow-hidden py-4 px-2">
+    <nav {...navProps} className="-mx-2 flex min-w-0 text-sm">
+      <ol className="flex w-fit items-center overflow-hidden py-4 px-2">
         <BreadcrumbItem url="/">
           <HomeIcon />
           <span className="sr-only">{t('homepage')}</span>

--- a/next/modules/common/Carousel/Carousel.tsx
+++ b/next/modules/common/Carousel/Carousel.tsx
@@ -78,9 +78,12 @@ const Carousel = ({
       </div>
       <ul
         className={twMerge(
-          cx('-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip lg:mx-0', {
-            'scrollbar-hide': hideScrollbar,
-          }),
+          cx(
+            '-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip px-4 lg:-mx-8 lg:px-8',
+            {
+              'scrollbar-hide': hideScrollbar,
+            }
+          ),
           listClassName
         )}
         ref={scrollerRef}

--- a/next/modules/common/Carousel/Carousel.tsx
+++ b/next/modules/common/Carousel/Carousel.tsx
@@ -76,7 +76,7 @@ const Carousel = ({
       </div>
       <ul
         className={twMerge(
-          cx('-mx-4 -my-2 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip py-2', {
+          cx('-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip lg:mx-0 ', {
             'scrollbar-hide': hideScrollbar,
           }),
           listClassName

--- a/next/modules/common/Carousel/Carousel.tsx
+++ b/next/modules/common/Carousel/Carousel.tsx
@@ -7,6 +7,7 @@ import CarouselControl, { CarouselControlDirection } from './CarouselControl'
 interface SectionPromosProps {
   listClassName?: string
   itemClassName?: string
+  className?: string
   items: { element: ReactNode; key: string | undefined }[]
   shiftIndex?: number
   visibleItemsCount?: number
@@ -16,6 +17,7 @@ interface SectionPromosProps {
 const Carousel = ({
   listClassName,
   itemClassName,
+  className,
   items,
   shiftIndex = 1,
   visibleItemsCount = 3,
@@ -64,7 +66,7 @@ const Carousel = ({
   }
 
   return (
-    <div className="relative">
+    <div className={twMerge(cx('relative'), className)}>
       <div className="hidden lg:block">
         {items.length >= visibleItemsCount && (
           <CarouselControl
@@ -76,7 +78,7 @@ const Carousel = ({
       </div>
       <ul
         className={twMerge(
-          cx('-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip lg:mx-0 ', {
+          cx('-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip lg:mx-0', {
             'scrollbar-hide': hideScrollbar,
           }),
           listClassName

--- a/next/modules/common/Carousel/Carousel.tsx
+++ b/next/modules/common/Carousel/Carousel.tsx
@@ -76,7 +76,7 @@ const Carousel = ({
       </div>
       <ul
         className={twMerge(
-          cx('-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip lg:mx-0 ', {
+          cx('-mx-4 -my-2 flex snap-x snap-mandatory overflow-x-auto overflow-y-clip py-2', {
             'scrollbar-hide': hideScrollbar,
           }),
           listClassName


### PR DESCRIPTION
### Description
Remove the “cropped look” of focus rings on several components. This occurs because the rings are rendered outside the elements’ bounding box, but they don’t affect the elements' size. So, the elements fit into their parents' containers, but the focus rings don’t, and get cropped

### Supplementary notes

- Cards displayed in `SectionPromos` (in `Carousel`) now have non-cropped focus rings
- However, when tabbing over the cards, they flash due to small changes in height
- This is because `h-full` was used instead of the former hard-coded values `h-[350px] md:h-[490px]`

### Screenshots
| Before | After |
|----------|----------|
| <img width="1369" alt="Screenshot 2025-01-22 at 12 24 01" src="https://github.com/user-attachments/assets/e5699281-e915-40bf-b51e-f6b5a2c97384" /> | <img width="1275" alt="Screenshot 2025-01-28 at 14 30 30" src="https://github.com/user-attachments/assets/f146eb1e-916f-4a4a-9d70-a29aa911afd3" /> |

### Testing
- Navigate to http://localhost:3000/ to check focus rings of the promo cards
<img width="1366" alt="Screenshot 2025-01-28 at 15 41 34" src="https://github.com/user-attachments/assets/18a97576-b9ba-4d02-9df1-a34e13a5057a" />


- Navigate to http://localhost:3000/navstivte/nase-lokality/klariska to check focus rings of breadcrumbs and "branch menu"
<img width="853" alt="Screenshot 2025-01-28 at 15 40 18" src="https://github.com/user-attachments/assets/70a81515-a0d0-4e90-b52d-1ad40b34d14a" />

- Navigate to http://localhost:3000/vyhladavanie to check focus rings of chip buttons and search results cards
<img width="498" alt="Screenshot 2025-01-28 at 15 38 16" src="https://github.com/user-attachments/assets/3e4728fb-c6cb-4534-8014-150cef1c41d0" />

- None of the focus rings should appear cropped from any side
