### PR TITLE
Update eslint and prettier configs

### DIFF
--- a/next/.eslintrc.js
+++ b/next/.eslintrc.js
@@ -1,24 +1,58 @@
 module.exports = {
-  extends: ['auto', 'plugin:tailwindcss/recommended', 'plugin:@next/next/recommended'],
-  plugins: ['only-warn'],
+  extends: [
+    'auto',
+    'plugin:tailwindcss/recommended',
+    'plugin:@next/next/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:lodash/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  plugins: [
+    'only-warn',
+    'prettier',
+    'jsx-a11y',
+    'lodash',
+    '@typescript-eslint',
+    '@next/next',
+    'simple-import-sort',
+    'tailwindcss',
+  ],
+  parser: '@typescript-eslint/parser', // Ensure correct parser for TypeScript
   rules: {
     'react/react-in-jsx-scope': 'off',
-    /** We use this a lot with isDefined and hasAttributes */
-    'unicorn/no-array-callback-reference': 'off',
-    /** Named export is easier to refactor automatically */
-    'import/prefer-default-export': 'off',
-    /** Too tedious to type every function return explicitly */
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    /** We prefer arrow functions */
-    'react/function-component-definition': [2, { namedComponents: 'arrow-function' }],
-    /** It's annoying to refactor from one style to another */
-    'arrow-body-style': 'off',
-    /** This are exceptions that we use with "__" */
+    'react/function-component-definition': [2, { namedComponents: 'arrow-function' }], // We prefer arrow functions
+    'react/require-default-props': 'off', // We specify default props in props decomposition
+
+    /** TypeScript */
+    '@typescript-eslint/explicit-function-return-type': 'off', // Too tedious to type every function return explicitly
+    '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
+
+    /** Accessibility */
+    'jsx-a11y/img-redundant-alt': 'warn',
+    'jsx-a11y/anchor-is-valid': 'off', // Next Link does not need href in <a> tag
+
+    /** Imports */
+    'import/prefer-default-export': 'off', // Named export is easier to refactor automatically
+    'import/extensions': 'off',
+
+    'prettier/prettier': 'error',
+    'unicorn/no-array-callback-reference': 'off', // We use this a lot with isDefined and hasAttributes
+    'arrow-body-style': 'off', // It's annoying to refactor from one style to another
+    'lodash/prefer-noop': 'off',
+    '@next/next/no-img-element': 'off',
+
+    // These are exceptions that we use with "__"
     'no-underscore-dangle': [
       2,
       { allow: ['__NEXT_DATA__', '__NEXT_LOADED_PAGES__', '__typename'] },
     ],
-    /** Links get confused for secrets */
+
+    // Links get confused for secrets
     'no-secrets/no-secrets': [
       'error',
       {
@@ -28,25 +62,10 @@ module.exports = {
         ],
       },
     ],
-    /** We specify default props in props decomposition */
-    'react/require-default-props': 'off',
-    /** Next Link does not need href in <a> tag */
-    'jsx-a11y/anchor-is-valid': 'off',
-    /** Do not work in our case */
-    '@typescript-eslint/no-unsafe-assignment': 'off',
-    '@typescript-eslint/no-unsafe-call': 'off',
-    '@typescript-eslint/no-unsafe-return': 'off',
-    '@typescript-eslint/no-unsafe-member-access': 'off',
-    '@typescript-eslint/no-unsafe-argument': 'off',
-    'lodash/prefer-noop': 'off',
-    'jsx-a11y/img-redundant-alt': 'warn',
-    '@next/next/no-img-element': 'off',
+
+    /** Does not work in our case */
     // https://github.com/jsx-eslint/eslint-plugin-react/issues/2584#issuecomment-1191175244
     'react/jsx-no-useless-fragment': [2, { allowExpressions: true }],
-    'import/extensions': 'off',
-
-    /* Formatting rules - based on OLO */
-    'prettier/prettier': ['error', { endOfLine: 'auto' }], // TODO revisit, prettier should not be run by eslint
   },
   ignorePatterns: ['*.config.*', 'graphql', '.eslintrc.js'],
 }

--- a/next/.prettierrc.js
+++ b/next/.prettierrc.js
@@ -1,9 +1,9 @@
 module.exports = {
-  trailingComma: 'all',
+  trailingComma: 'es5',
   tabWidth: 2,
   semi: false,
   singleQuote: true,
   printWidth: 100,
   plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: ['cx', 'classnames', 'clsx', 'cn', 'twMerge', 'tw'],
+  tailwindFunctions: ['clsx', 'cn', 'twMerge'],
 }


### PR DESCRIPTION
### Description

**.prettierrc.js**
- Use `trailingComma: 'es5'` as in other repos
- Include only the functions we currently use in the `tailwindFunctions` array

**.eslintrc.js**
- Plugins we use and want to define rules for should be included in `plugins` - this ensures that `eslint` recognises them, and applies their rules during linting
- Additions to `extends` - to extend the recommended set of rules for the given plugins

### Supplementary notes
- Prettier also formats yaml files. Do we want to include or exclude them in formatting?

### Testing

- Run `cd next && yarn eslint .` - you should see more warnings than before since more plugins were enabled
- Run `yarn lint --fix` to fix some warnings, several files should be reformatted
- Run `yarn prettier --write` to apply Prettier rules, several files should be reformatted

It does not matter whether Prettier or `eslint` runs first - they should complement each other rather than conflict

### Screenshots
<img width="563" alt="Screenshot 2025-02-09 at 17 16 25" src="https://github.com/user-attachments/assets/c4f5412e-0e5a-449e-8570-791861d9768d" />

**This error was addressed by adding Prettier into eslint plugins**

&nbsp;

<img width="1080" alt="Screenshot 2025-02-09 at 17 19 22" src="https://github.com/user-attachments/assets/a3623d13-bb21-4fb2-be46-5c7efeebc49e" />

**We now, for example, receive lodash warnings since lodash was added into eslint plugins**

&nbsp;

<img width="503" alt="Screenshot 2025-02-09 at 17 28 18" src="https://github.com/user-attachments/assets/5f557eaa-8921-4fc4-ae13-b88cf552f9c9" />

**Extra spaces in Tailwind classes will be deleted**

&nbsp;

<img width="1719" alt="Screenshot 2025-02-09 at 17 31 32" src="https://github.com/user-attachments/assets/a5c91eba-7ccd-4981-b83c-3efebb49cd5e" />

<img width="1714" alt="Screenshot 2025-02-09 at 17 35 56" src="https://github.com/user-attachments/assets/630f4dfc-f4d0-4817-89ed-d15231649fc8" />


**Prettier fixes indentation issues**


&nbsp;

<img width="1463" alt="Screenshot 2025-02-09 at 17 34 32" src="https://github.com/user-attachments/assets/5bc756b1-83ea-4db6-8a6b-e1c9e6c0cf27" />


**Sorts Tailwind classes**