### PR TITLE
#399 Update libs in Navikronos strapi plugin

### DIFF
--- a/strapi/package.json
+++ b/strapi/package.json
@@ -18,9 +18,10 @@
     "@strapi/plugin-users-permissions": "4.25.20",
     "@strapi/strapi": "4.25.20",
     "pg": "^8.13.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-router-dom": "^5.2.0",
+    "postinstall-postinstall": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "5.3.4",
     "strapi-plugin-meilisearch": "^0.9.2",
     "strapi-provider-upload-ts-minio": "^3.1.0",
     "styled-components": "^5.2.1"

--- a/strapi/src/plugins/navikronos/admin/src/pages/App.tsx
+++ b/strapi/src/plugins/navikronos/admin/src/pages/App.tsx
@@ -1,9 +1,8 @@
-import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { NotFound } from "@strapi/helper-plugin";
+import { AnErrorOccurred } from "@strapi/helper-plugin";
 import pluginId from "../pluginId";
 import HomePage from "./Homepage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const queryClient = new QueryClient();
 
@@ -13,7 +12,7 @@ const App = () => {
       <div>
         <Switch>
           <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
-          <Route component={NotFound} />
+          <Route component={AnErrorOccurred} />
         </Switch>
       </div>
     </QueryClientProvider>

--- a/strapi/src/plugins/navikronos/admin/src/utils/NavigationDataProvider.tsx
+++ b/strapi/src/plugins/navikronos/admin/src/utils/NavigationDataProvider.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   Dispatch,
   PropsWithChildren,
@@ -8,7 +8,7 @@ import React, {
   useReducer,
   useState,
 } from "react";
-import { useMutation, useQuery } from "react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { fetchNavigation, putNavigation } from "./api";
 import {
   NavikronosEmptyRoute,
@@ -34,7 +34,8 @@ const NavigationDataDispatchContext =
 export const NavigationDataProvider = ({ children }: PropsWithChildren) => {
   const [navigationData, dispatch] = useReducer(navigationDataReducer, null);
 
-  const { data, isLoading, isError } = useQuery("navigation", {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["navigation"],
     queryFn: fetchNavigation,
     staleTime: Infinity,
   });
@@ -113,7 +114,7 @@ type NavigationDataAction =
 
 function navigationDataReducer(
   navigationData: NavikronosLocaleNavigations | null,
-  action: NavigationDataAction
+  action: NavigationDataAction,
 ) {
   if (action.type === "loaded") {
     return action.data;
@@ -223,7 +224,7 @@ function navigationDataReducer(
           throw Error("Unknown action: " + (action as { type: string }).type);
         }
       }
-    }
+    },
   ).children;
 
   return { ...navigationData, [action.locale]: editedLocale };
@@ -231,7 +232,7 @@ function navigationDataReducer(
 
 export const useHasNavigationData = () => {
   const { isError, isLoading, navigationData } = useContext(
-    NavigationDataContext
+    NavigationDataContext,
   )!;
   const dispatch = useContext(NavigationDataDispatchContext);
 
@@ -243,32 +244,31 @@ export const useHasNavigationData = () => {
  */
 export const useNavigationDataDefined = () => {
   const { navigationData, locale, setLocale } = useContext(
-    NavigationDataContext
+    NavigationDataContext,
   )!;
   const toggleNotification = useNotification();
   const dispatch = useContext(NavigationDataDispatchContext);
-  const { mutate, isLoading: isSaving } = useMutation(
-    (newNavigationData: NavikronosLocaleNavigations) =>
+  const { mutate, isPending: isSaving } = useMutation({
+    mutationFn: (newNavigationData: NavikronosLocaleNavigations) =>
       putNavigation({ navigation: newNavigationData }),
-    {
-      onSuccess: () => {
-        toggleNotification({
-          type: "success",
-          message: "Navigation saved successfully.",
-        });
-      },
-      onError: () => {
-        toggleNotification({
-          type: "warning",
-          message: "Navigation failed to save.",
-        });
-      },
-    }
-  );
+
+    onSuccess: () => {
+      toggleNotification({
+        type: "success",
+        message: "Navigation saved successfully.",
+      });
+    },
+    onError: () => {
+      toggleNotification({
+        type: "warning",
+        message: "Navigation failed to save.",
+      });
+    },
+  });
 
   if (!navigationData || !dispatch) {
     throw new Error(
-      "useNavigationDataDefined has been used on a place not protected by useHasNavigationData"
+      "useNavigationDataDefined has been used on a place not protected by useHasNavigationData",
     );
   }
 
@@ -278,7 +278,7 @@ export const useNavigationDataDefined = () => {
 
   const editRoute = (
     locationIndexes: number[],
-    editedRoute: NavikronosRoute
+    editedRoute: NavikronosRoute,
   ) => {
     dispatch({
       type: "editRoute",

--- a/strapi/src/plugins/navikronos/admin/src/utils/useConfig.ts
+++ b/strapi/src/plugins/navikronos/admin/src/utils/useConfig.ts
@@ -1,8 +1,9 @@
-import { useQuery } from "react-query";
+import { useQuery } from "@tanstack/react-query";
 import { fetchConfig } from "./api";
 
 export const useConfig = () => {
-  const { data, isLoading, isError } = useQuery("config", {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["config"],
     queryFn: fetchConfig,
     staleTime: Infinity,
   });
@@ -28,7 +29,7 @@ export const useConfigDefined = () => {
 
   if (!config) {
     throw new Error(
-      "useConfigDefined has been used on a place not protected by useConfigDefined"
+      "useConfigDefined has been used on a place not protected by useConfigDefined",
     );
   }
 

--- a/strapi/src/plugins/navikronos/package.json
+++ b/strapi/src/plugins/navikronos/package.json
@@ -8,15 +8,15 @@
   },
   "dependencies": {
     "@strapi/helper-plugin": "4.25.20",
+    "@tanstack/react-query": "5.66.0",
     "immer": "^9.0.18",
     "lodash": "^4.17.21",
-    "react-query": "^3.39.2",
     "strapi-typed": "^1.0.20",
     "styled-components": "^5.3.6",
-    "zod": "^3.20.2"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   },
   "author": {
     "name": "A Strapi developer"

--- a/strapi/src/plugins/navikronos/yarn.lock
+++ b/strapi/src/plugins/navikronos/yarn.lock
@@ -1332,6 +1332,18 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tanstack/query-core@5.66.0":
+  version "5.66.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.66.0.tgz#163f670b3b4e3b3cdbff6698ad44b2edfcaed185"
+  integrity sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==
+
+"@tanstack/react-query@5.66.0":
+  version "5.66.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.66.0.tgz#9f7aa1b3e844ea6a0ad2ee61fccaed76e614b865"
+  integrity sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==
+  dependencies:
+    "@tanstack/query-core" "5.66.0"
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -2705,15 +2717,6 @@ react-query@3.39.3:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
-react-query@^3.39.2:
-  version "3.39.2"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.2.tgz#9224140f0296f01e9664b78ed6e4f69a0cc9216f"
-  integrity sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    broadcast-channel "^3.4.1"
-    match-sorter "^6.0.2"
-
 react-remove-scroll-bar@^2.3.7:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
@@ -2965,10 +2968,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.4:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 unload@2.2.0:
   version "2.2.0"
@@ -3082,7 +3085,7 @@ yup@0.32.9:
     property-expr "^2.0.4"
     toposort "^2.0.2"
 
-zod@^3.20.2:
-  version "3.20.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
-  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==
+zod@^3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
+  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==

--- a/strapi/yarn.lock
+++ b/strapi/yarn.lock
@@ -8876,6 +8876,11 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
+
 prebuild-install@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
@@ -9083,7 +9088,7 @@ react-dnd@16.0.1:
     fast-deep-equal "^3.1.3"
     hoist-non-react-statics "^3.3.2"
 
-react-dom@^18.0.0:
+react-dom@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -9194,7 +9199,7 @@ react-remove-scroll@^2.5.9, react-remove-scroll@^2.6.2:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-react-router-dom@^5.2.0:
+react-router-dom@5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
   integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
@@ -9268,7 +9273,7 @@ react-window@1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18.0.0:
+react@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
### Description

Added `postinstall-postinstall` to install and build correctly also plugins in Strapi.
Update `@tanstack/react-query`
Update react, typescript to versions as in olo.

### Testing

In strapi folder, `yarn install` and `yarn build` should be run also for plugins.

Install, build and run strapi, it should run correctly.
Changes in Navikronos strapi admin panel should be seen also on FE (e.g. in breadcrumbs)

### Supplementary notes

Replaced `NotFound` (that did not exist in package) to `AnErrorOccurred` component (as it is in OLO)

