### PR TITLE
#421 Fix incorrect resizing of banner image

### DIFF
--- a/next/components/Molecules/EventDetails.tsx
+++ b/next/components/Molecules/EventDetails.tsx
@@ -46,16 +46,15 @@ const EventDetails = ({ event }: PageProps) => {
 
   return (
     <>
-      <div className="relative w-full shrink-0 md:h-75 lg:h-[400px]">
-        <StrapiImage
-          image={
-            event?.attributes?.coverImage?.data?.attributes ||
-            getImagePlaceholder(EventDetailPlaceholder)
-          }
-          alt="" // Empty alt on purpose
-          className="object-cover"
-        />
-      </div>
+      <StrapiImage
+        image={
+          event?.attributes?.coverImage?.data?.attributes ||
+          getImagePlaceholder(EventDetailPlaceholder)
+        }
+        alt="" // Empty alt on purpose
+        className="w-full object-cover md:h-75 lg:h-[400px]"
+      />
+
       <div className="block grid-cols-9 gap-x-16 pt-10 lg:grid">
         <div className="col-span-1 hidden size-27 bg-promo-yellow text-center lg:flex">
           <EventDetailsDateBox


### PR DESCRIPTION
### Description
The sizes needed to be applied directly to the image, not to its container

### Screenshots
<img width="1368" alt="Screenshot 2025-02-13 at 11 15 11" src="https://github.com/user-attachments/assets/acfe4e4d-2df1-4821-b66c-5da15b5f77dd" />

<img width="1380" alt="Screenshot 2025-02-13 at 11 16 07" src="https://github.com/user-attachments/assets/a591c640-35a6-4a15-9951-57466968da48" />

### Testing
- See if images at `zazite/podujatia/noc-literatury` and `zazite/podujatia/chobotnicka-emka-1` resize correctly
- (Just in case, see if other images resize correctly too)

