### PR TITLE
Remove SSRProvider as it is not needed in React 18

### DIFF
--- a/next/next-env.d.ts
+++ b/next/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -5,7 +5,7 @@ import Script from 'next/script'
 import { appWithTranslation } from 'next-i18next'
 import PlausibleProvider from 'next-plausible'
 import { NextAdapter } from 'next-query-params'
-import { OverlayProvider, SSRProvider } from 'react-aria'
+import { OverlayProvider } from 'react-aria'
 import { QueryParamProvider } from 'use-query-params'
 
 import ErrorDisplay from '@/components/Molecules/ErrorDisplay'
@@ -35,21 +35,19 @@ const CustomApp = ({ Component, pageProps }: AppProps) => {
         taggedEvents
         enabled={isProductionDeployment()}
       />
-      <SSRProvider>
-        <NavikronosConfigProvider config={navikronosConfig}>
-          <MQueryClientProvider>
-            <MI18nProvider>
-              <OverlayProvider>
-                <QueryParamProvider adapter={NextAdapter}>
-                  <NavMenuContextProvider>
-                    <Component id="root" {...pageProps} />
-                  </NavMenuContextProvider>
-                </QueryParamProvider>
-              </OverlayProvider>
-            </MI18nProvider>
-          </MQueryClientProvider>
-        </NavikronosConfigProvider>
-      </SSRProvider>
+      <NavikronosConfigProvider config={navikronosConfig}>
+        <MQueryClientProvider>
+          <MI18nProvider>
+            <OverlayProvider>
+              <QueryParamProvider adapter={NextAdapter}>
+                <NavMenuContextProvider>
+                  <Component id="root" {...pageProps} />
+                </NavMenuContextProvider>
+              </QueryParamProvider>
+            </OverlayProvider>
+          </MI18nProvider>
+        </MQueryClientProvider>
+      </NavikronosConfigProvider>
     </div>
   )
 }


### PR DESCRIPTION
### Description

Remove SSRProvider as it is not needed in React 18. https://react-spectrum.adobe.com/react-aria/SSRProvider.html#introduction

### Testing

No testing needed.