### PR TITLE
#431 plausible tracking file downloads and 404 error page

### DIFF
--- a/next/pages/404.tsx
+++ b/next/pages/404.tsx
@@ -2,6 +2,8 @@ import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { usePlausible } from 'next-plausible'
+import { useEffect } from 'react'
 
 import DefaultPageLayout from '@/components/layouts/DefaultPageLayout'
 import ErrorPage from '@/components/pages/ErrorPage'
@@ -21,6 +23,12 @@ const Custom404 = ({ general }: Error404PageProps) => {
   const { t, i18n } = useTranslation()
 
   const { asPath } = useRouter()
+
+  const plausible = usePlausible()
+
+  useEffect(() => {
+    plausible('404', { props: { path: document.location.pathname } })
+  }, [plausible])
 
   return (
     <GeneralContextProvider general={general}>

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -33,6 +33,7 @@ const CustomApp = ({ Component, pageProps }: AppProps) => {
       <PlausibleProvider
         domain="mestskakniznica.sk"
         taggedEvents
+        trackFileDownloads
         enabled={isProductionDeployment()}
       />
       <NavikronosConfigProvider config={navikronosConfig}>


### PR DESCRIPTION
### Testing (possible in production only)
- check if everything is tracked properly on https://plausible.io/mestskakniznica.sk
  - visit a nonexisting page so that you end up on the 404 page - in the _Goal Conversions_ section at the bottom of the plausible dashboard, a 404 event should appear with information abou the path that the user tried to visit
  - download a file (e.g. from the [Dokumenty page](https://www.mestskakniznica.sk/o-nas/dokumenty-a-zverejnovanie-informacii) and check the _Goal Conversions_ section in plausible dashboard - the download should appear there. To see which file extensions are availlible to track, see the [Which file types are tracked?](https://plausible.io/docs/file-downloads-tracking#which-file-types-are-tracked) part of plausible documentation


